### PR TITLE
rename partition for clarity

### DIFF
--- a/lib/vispana_web/live/content_live/index.html.leex
+++ b/lib/vispana_web/live/content_live/index.html.leex
@@ -50,7 +50,7 @@
                                 </div>
                                 <div>
                                   <p class="mt-2 text-xs text-gray-200">
-                                      <span >Partitions: </span> <span class="text-gray-400"><%= contentCluster.partitions %></span>
+                                      <span >Partition groups: </span> <span class="text-gray-400"><%= contentCluster.partitions %></span>
                                       |
                                       <span >Searchable copies: </span> <span class="text-gray-400"><%= contentCluster.searchableCopies %></span>
                                       |


### PR DESCRIPTION
Small change to rename "Partitions:" to "Partition groups:". The`<distribution partitions="1|1|1|*" />` tag is a bit misleading, as the number of items actually represents the number of content groups and not the partitions.