### PR TITLE
Support multiarch docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.12
+FROM elixir:1.15
 
 # Container setup. Docker caches a layer for each RUN statement.
 RUN mkdir -p /app/assets  # The directory structure we will need to run the app.

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+docker build -t vispana/vispana:0.0.3 .


### PR DESCRIPTION
Bumps Elixir docker image version to support M1 chips containers. See [https://github.com/vispana/vispana/pull/31](https://github.com/vispana/vispana/pull/31) for more details on other steps required to bump the version