### PR TITLE
fix(add-query-keybindings)

### DIFF
--- a/src/main/js/components/editor/editor.js
+++ b/src/main/js/components/editor/editor.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useEffect} from "react";
 import AceEditor from "react-ace";
 import "ace-builds/src-noconflict/mode-json";
 import "ace-builds/src-noconflict/snippets/json";
@@ -8,7 +8,7 @@ import "ace-builds/src-noconflict/ext-language_tools";
 import {LanguageProvider} from "ace-linters/build/ace-linters";
 import schema from "./query-schema"
 
-function Editor({query, setQuery}) {
+function Editor({query, setQuery, handleRunQuery}) {
     const provider = LanguageProvider.fromCdn("https://cdn.jsdelivr.net/npm/ace-linters/build");
     //link schema to json service
     provider.setGlobalOptions("json", {
@@ -20,7 +20,21 @@ function Editor({query, setQuery}) {
         ]
     });
 
+    const editorRef = React.useRef(null);
+    useEffect(() => {
+        if (editorRef?.current?.editor) {
+            const editor = editorRef.current.editor
+            editor.commands.addCommands([{
+                name: 'run query',
+                exec: handleRunQuery,
+                bindKey: {mac: "Command-Enter"}
+            }])
+        }
+    }, [editorRef?.current?.editor])
+
+
     return (<AceEditor
+        ref={editorRef}
         height={"210px"}
         placeholder="Placeholder Text"
         mode="json"

--- a/src/main/js/components/editor/editor.js
+++ b/src/main/js/components/editor/editor.js
@@ -27,7 +27,7 @@ function Editor({query, setQuery, handleRunQuery}) {
             editor.commands.addCommands([{
                 name: 'run query',
                 exec: handleRunQuery,
-                bindKey: {mac: "Command-Enter"}
+                bindKey: {mac: "Command-Enter", win: "Ctrl-Enter"}
             }])
         }
     }, [editorRef?.current?.editor])

--- a/src/main/js/components/query-result/query-result.js
+++ b/src/main/js/components/query-result/query-result.js
@@ -4,7 +4,6 @@ import {androidstudio} from "react-syntax-highlighter/dist/cjs/styles/hljs";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import Loading from "../../routes/loading/loading";
 import VispanaError from "../../routes/error/vispana-error";
-import {useRevalidator} from "react-router-dom";
 
 function QueryResult({containerUrl, vispanaClient, query, showResults, schema, refreshQuery, defaultPageSize = 15}) {
     // customize theme

--- a/src/main/js/routes/schema/query.js
+++ b/src/main/js/routes/schema/query.js
@@ -57,10 +57,7 @@ function Query({containerUrl, schema}) {
 
 export function defaultQuery(schema) {
     return JSON.stringify({
-        yql: `SELECT *
-              from ${schema}
-              where true`
-    }, null, 2);
+        yql: `SELECT * from ${schema} where true` }, null, 2);
 }
 
 export default Query

--- a/src/main/js/routes/schema/query.js
+++ b/src/main/js/routes/schema/query.js
@@ -2,13 +2,17 @@ import Editor from "../../components/editor/editor";
 import React, {useEffect, useState} from "react";
 import VispanaApiClient from "../../client/vispana-api-client";
 import QueryResult from "../../components/query-result/query-result";
-import { v4 as uuidv4 } from 'uuid';
+import {v4 as uuidv4} from 'uuid';
 
 function Query({containerUrl, schema}) {
-    function handleClick(event) {
-        event.preventDefault()
+    function runQuery() {
         setShowResults(true)
         setRefreshQuery(uuidv4())
+    }
+
+    function handleClick(event) {
+        event.preventDefault()
+        runQuery()
     }
 
     const vispanaClient = new VispanaApiClient()
@@ -23,7 +27,7 @@ function Query({containerUrl, schema}) {
 
     return <div className={"min-w-full"}>
         <form>
-            <Editor query={query} setQuery={setQuery}/>
+            <Editor query={query} setQuery={setQuery} handleRunQuery={runQuery}/>
             <div className="form-control mb-2">
                 <div className={"min-w-full text-right"}>
                     <a className={"text-sm underline"}
@@ -53,8 +57,9 @@ function Query({containerUrl, schema}) {
 
 export function defaultQuery(schema) {
     return JSON.stringify({
-        yql: `SELECT * from ${schema} where true`,
-        hits: 30
+        yql: `SELECT *
+              from ${schema}
+              where true`
     }, null, 2);
 }
 


### PR DESCRIPTION
- remove the `hits: 30` from the default query since it is not used, we set the hits + offsets with navigation in the query-resutls
- add keybinding for run the query, cmd+enter on mac and ctrl+enter on linux and windows