### PR TITLE
feat: add option to trace queries

### DIFF
--- a/src/main/js/routes/schema/query.js
+++ b/src/main/js/routes/schema/query.js
@@ -23,6 +23,22 @@ function Query({containerUrl, schema}) {
         }
     }
 
+    function addTrace() {
+        try {
+            const parsed = JSON.parse(query)
+            if ("trace" in parsed) {
+                return // don't overwrite if it's already there
+            }
+            parsed["trace"] = {
+                "level": 5,
+                "explainLevel": 1,
+                "timestamps": true
+            }
+            setQuery(JSON.stringify(parsed, null, 2))
+        } catch (_) {
+        }
+    }
+
     const vispanaClient = new VispanaApiClient()
     const [query, setQuery] = useState(defaultQuery(schema))
     const [showResults, setShowResults] = useState(false)
@@ -57,6 +73,14 @@ function Query({containerUrl, schema}) {
                 <i className="fas fa-code block"/>
             </button>
             <button type="button"
+                    className="btn bg-standout-blue text-yellow-400 w-13 text-center border-none outline-none mr-1"
+                    data-tooltip-id="vispana-tooltip"
+                    data-tooltip-content="Add Trace"
+                    data-tooltip-place="top"
+                    onClick={addTrace}>
+                <i className="fas fa-search block"/>
+            </button>
+            <button type="button"
                     className="btn bg-standout-blue text-yellow-400 w-32 btn-blue border-none outline-none"
                     data-tooltip-id="vispana-tooltip"
                     data-tooltip-content="Query (Cmd+Enter)"
@@ -75,7 +99,8 @@ function Query({containerUrl, schema}) {
                          schema={schema}
                          render={showResults}
                          refreshQuery={refreshQuery}
-                         vispanaClient={vispanaClient}/>
+                         vispanaClient={vispanaClient}
+                         useTabs={true}/>
         </div>}
         <Tooltip id="vispana-tooltip" />
     </div>


### PR DESCRIPTION
Add the option to easily trace to a query.

There is a new button (feel free to change the icon):
<img width="1710" alt="Screenshot 2023-12-11 at 08 02 24" src="https://github.com/vispana/vispana/assets/1022924/03563fb7-6d07-4b0a-9be9-15f8d0a0521f">

When clicked, it adds default tracing options to the query:
<img width="1708" alt="Screenshot 2023-12-11 at 08 02 34" src="https://github.com/vispana/vispana/assets/1022924/6126a0be-5c5c-4d53-a914-d1d015c2cbd6">

After clicking Query, the results and tracing data are shown in separate tabs:
<img width="1711" alt="Screenshot 2023-12-11 at 08 03 29" src="https://github.com/vispana/vispana/assets/1022924/c3e307b1-587c-40ed-92f2-736d4c609cf8">
