### PR TITLE
if tracing is enabled, hide from json results

### DIFF
--- a/src/main/js/components/query-result/query-result.js
+++ b/src/main/js/components/query-result/query-result.js
@@ -270,7 +270,11 @@ function processResult(result) {
         return fields
     })
 
-    const trace = "trace" in result ? result.trace.children : []
+    let trace = []
+    if ("trace" in result) {
+        trace = result.trace.children
+        result["trace"] = "...see trace tab..."
+    }
 
     return {
         columns: columns,


### PR DESCRIPTION
The json response tab is great! When tracing though, the trace data shows up first and you have to scroll a long way to get to the "root" information. This PR adds a check if tracing results are included and hides them from view in the json response tab.

<img width="404" alt="Screenshot 2024-01-10 at 21 47 48" src="https://github.com/vispana/vispana/assets/1022924/e8c40ddf-1644-415f-be88-a26967f972ba">
