### PR TITLE
feat(App Package): Visualization for Models, QueryProfiles & QueryProfileTypes

### DIFF
--- a/src/main/java/com/vispana/api/model/apppackage/ApplicationPackage.java
+++ b/src/main/java/com/vispana/api/model/apppackage/ApplicationPackage.java
@@ -1,5 +1,13 @@
 package com.vispana.api.model.apppackage;
 
+import java.util.List;
+import java.util.Map;
+
 // Application package
 public record ApplicationPackage(
-    String appPackageGeneration, String servicesContent, String hostsContent) {}
+    String appPackageGeneration,
+    String servicesContent,
+    String hostsContent,
+    List<String> modelsContent,
+    Map<String, String> queryProfilesContent,
+    Map<String, String> queryProfileTypesContent) {}

--- a/src/main/java/com/vispana/vespa/state/assemblers/AppPackageAssembler.java
+++ b/src/main/java/com/vispana/vespa/state/assemblers/AppPackageAssembler.java
@@ -5,6 +5,9 @@ import static com.vispana.vespa.state.helpers.Request.requestGetWithDefaultValue
 
 import com.vispana.api.model.apppackage.ApplicationPackage;
 import com.vispana.client.vespa.model.ApplicationSchema;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class AppPackageAssembler {
 
@@ -13,7 +16,91 @@ public class AppPackageAssembler {
     var hostContent = requestGetWithDefaultValue(appUrl + "/content/hosts.xml", String.class, "");
     var servicesContent = requestGet(appUrl + "/content/services.xml", String.class);
 
+    List<String> modelsContent =
+        requestGetWithDefaultValue(appUrl + "/content/models/", List.class, List.of());
+
+    // Parse JSON array and extract model names
+    if (modelsContent.isEmpty()) {
+      modelsContent = List.of();
+    } else {
+      try {
+        modelsContent =
+            modelsContent.stream()
+                .map(
+                    fullUrl -> {
+                      // Subtract filename from URL
+                      int lastSlashIndex = fullUrl.lastIndexOf('/');
+                      return lastSlashIndex >= 0 ? fullUrl.substring(lastSlashIndex + 1) : fullUrl;
+                    })
+                .toList();
+      } catch (Exception e) {
+        // Handle JSON parsing error - return empty list or throw exception
+        modelsContent = List.of("Error parsing models");
+      }
+    }
+
+    Map<String, String> queryProfilesContent = new HashMap<String, String>();
+    List<String> queryProfileNames =
+        requestGetWithDefaultValue(
+            appUrl + "/content/search/query-profiles/", List.class, List.of());
+    if (!queryProfileNames.isEmpty()) {
+      try {
+        queryProfileNames =
+            queryProfileNames.stream()
+                .map(
+                    fullUrl -> {
+                      // Subtract filename from URL
+                      int lastSlashIndex = fullUrl.lastIndexOf('/');
+                      return lastSlashIndex >= 0 ? fullUrl.substring(lastSlashIndex + 1) : fullUrl;
+                    })
+                .filter(name -> name.endsWith(".xml"))
+                .toList();
+        for (String queryProfileName : queryProfileNames) {
+          queryProfilesContent.put(
+              queryProfileName,
+              requestGetWithDefaultValue(
+                  appUrl + "/content/search/query-profiles/" + queryProfileName, String.class, ""));
+        }
+      } catch (Exception e) {
+        queryProfilesContent = Map.of("Error", "Error parsing query profiles");
+      }
+    }
+
+    Map<String, String> queryProfileTypesContent = new HashMap<String, String>();
+    List<String> queryProfileTypeNames =
+        requestGetWithDefaultValue(
+            appUrl + "/content/search/query-profiles/types/", List.class, List.of());
+    if (!queryProfileTypeNames.isEmpty()) {
+      try {
+        queryProfileTypeNames =
+            queryProfileTypeNames.stream()
+                .map(
+                    fullUrl -> {
+                      // Subtract filename from URL
+                      int lastSlashIndex = fullUrl.lastIndexOf('/');
+                      return lastSlashIndex >= 0 ? fullUrl.substring(lastSlashIndex + 1) : fullUrl;
+                    })
+                .filter(name -> name.endsWith(".xml"))
+                .toList();
+        for (String queryProfileTypeName : queryProfileTypeNames) {
+          queryProfileTypesContent.put(
+              queryProfileTypeName,
+              requestGetWithDefaultValue(
+                  appUrl + "/content/search/query-profiles/types/" + queryProfileTypeName,
+                  String.class,
+                  ""));
+        }
+      } catch (Exception e) {
+        queryProfileTypesContent = Map.of("Error", "Error parsing query profile types");
+      }
+    }
+
     return new ApplicationPackage(
-        appSchema.getGeneration().toString(), servicesContent, hostContent);
+        appSchema.getGeneration().toString(),
+        servicesContent,
+        hostContent,
+        modelsContent,
+        queryProfilesContent,
+        queryProfileTypesContent);
   }
 }

--- a/src/main/js/routes/apppackage/app-package.js
+++ b/src/main/js/routes/apppackage/app-package.js
@@ -40,6 +40,60 @@ function AppPackage() {
         })
     }
 
+    // possibly add models
+    let modelsContent = vespaState.applicationPackage.modelsContent;
+    if (modelsContent.length > 0) {
+        tabsContent.push({
+            "tabName": "models",
+            "payload": JSON.stringify(modelsContent, null, 2),
+            "contentType": "json"
+        })
+    }
+    
+    // possibly add query-profiles with their XML content
+    let queryProfilesContent = vespaState.applicationPackage.queryProfilesContent;
+    // queryProfilesContent is a Map<String, String>
+    if (Object.keys(queryProfilesContent).length > 0) {
+        // Create a combined payload with all query profile XML contents
+        const combinedQueryProfiles = Object.entries(queryProfilesContent)
+            .map(([profileName, content]) => {
+                if (content) {
+                    return `<!-- ${profileName} -->\n${content}`;
+                } else {
+                    return `<!-- ${profileName} -->\n<!-- Error loading query profile -->`;
+                }
+            })
+            .join('\n\n');
+            
+        tabsContent.push({
+            "tabName": "query-profiles",
+            "payload": combinedQueryProfiles,
+            "contentType": "xml"
+        })
+    }
+    
+    // possibly add query-profile-types with their XML content
+    let queryProfileTypesContent = vespaState.applicationPackage.queryProfileTypesContent;
+    // queryProfileTypesContent is a Map<String, String>
+    if (Object.keys(queryProfileTypesContent).length > 0) {
+        // Create a combined payload with all query profile type XML contents
+        const combinedQueryProfileTypes = Object.entries(queryProfileTypesContent)
+            .map(([profileTypeName, content]) => {
+                if (content) {
+                    return `<!-- ${profileTypeName} -->\n${content}`;
+                } else {
+                    return `<!-- ${profileTypeName} -->\n<!-- Error loading query profile type -->`;
+                }
+            })
+            .join('\n\n');
+            
+        tabsContent.push({
+            "tabName": "query-profile-types",
+            "payload": combinedQueryProfileTypes,
+            "contentType": "xml"
+        })
+    }
+
     // add the schemas
     tabsContent.push(...schemas)
 

--- a/src/test/java/com/vispana/vespa/state/helpers/ContentNodesExtractorTest.java
+++ b/src/test/java/com/vispana/vespa/state/helpers/ContentNodesExtractorTest.java
@@ -8,6 +8,7 @@ import com.vispana.Helper;
 import com.vispana.api.model.apppackage.ApplicationPackage;
 import com.vispana.client.vespa.model.content.Node;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ContentNodesExtractorTest {
@@ -17,7 +18,8 @@ class ContentNodesExtractorTest {
     String hostsXmlString = defaultHostsXmlString();
     String servicesXmlString = defaultServicesXmlString();
     ApplicationPackage applicationPackage =
-        new ApplicationPackage("1", servicesXmlString, hostsXmlString);
+        new ApplicationPackage(
+            "1", servicesXmlString, hostsXmlString, List.of(), Map.of(), Map.of());
     List<Node> nodes =
         ContentNodesExtractor.contentNodesFromAppPackage(applicationPackage, "config.host.name");
 
@@ -38,7 +40,8 @@ class ContentNodesExtractorTest {
     String hostsXmlString = defaultHostsXmlString();
     String servicesXmlString = Helper.servicesXmlString("xml/services-single-group.xml");
     ApplicationPackage applicationPackage =
-        new ApplicationPackage("1", servicesXmlString, hostsXmlString);
+        new ApplicationPackage(
+            "1", servicesXmlString, hostsXmlString, List.of(), Map.of(), Map.of());
     List<Node> nodes =
         ContentNodesExtractor.contentNodesFromAppPackage(applicationPackage, "config.host.name");
 
@@ -60,7 +63,8 @@ class ContentNodesExtractorTest {
     String servicesXmlString =
         Helper.servicesXmlString("xml/services-single-group-single-host.xml");
     ApplicationPackage applicationPackage =
-        new ApplicationPackage("1", servicesXmlString, hostsXmlString);
+        new ApplicationPackage(
+            "1", servicesXmlString, hostsXmlString, List.of(), Map.of(), Map.of());
     List<Node> nodes =
         ContentNodesExtractor.contentNodesFromAppPackage(applicationPackage, "config.host.name");
 
@@ -77,7 +81,8 @@ class ContentNodesExtractorTest {
     String hostsXmlString = defaultHostsXmlString();
     String servicesXmlString = Helper.servicesXmlString("xml/services-no-group.xml");
     ApplicationPackage applicationPackage =
-        new ApplicationPackage("1", servicesXmlString, hostsXmlString);
+        new ApplicationPackage(
+            "1", servicesXmlString, hostsXmlString, List.of(), Map.of(), Map.of());
     List<Node> nodes =
         ContentNodesExtractor.contentNodesFromAppPackage(applicationPackage, "config.host.name");
 
@@ -98,7 +103,8 @@ class ContentNodesExtractorTest {
     String hostsXmlString = ""; // Single host does not require hosts.xml
     String servicesXmlString = Helper.servicesXmlString("xml/services-single-host.xml");
     ApplicationPackage applicationPackage =
-        new ApplicationPackage("1", servicesXmlString, hostsXmlString);
+        new ApplicationPackage(
+            "1", servicesXmlString, hostsXmlString, List.of(), Map.of(), Map.of());
     List<Node> nodes =
         ContentNodesExtractor.contentNodesFromAppPackage(applicationPackage, "config.host.name");
 


### PR DESCRIPTION
I propose this PR to be able to:
- list ml models currently deployed in vespa, if any
- list and read query profiles xml, if any
- list and read query profiles types xml, if any

I would also like to be able to list the components (or even be able to navigate through them, as in a file explorer), but this might not be that easy, given that `:19071/application/v2/tenant/default/session/[session-id]/content/components/` is a `.jar` export.

I did not add tests yet, but if this proposal is considered a nice contribution, I commit to add better tests of course :)