### PR TITLE
feat(Add Not Yet converged): Information for each content node, whose config is late

### DIFF
--- a/src/main/java/com/vispana/api/model/HostMetrics.java
+++ b/src/main/java/com/vispana/api/model/HostMetrics.java
@@ -1,3 +1,3 @@
 package com.vispana.api.model;
 
-public record HostMetrics(double cpuUsage, double memoryUsage, double diskUsage) {}
+public record HostMetrics(double cpuUsage, double memoryUsage, double diskUsage, int notYetConverged) {}

--- a/src/main/java/com/vispana/api/model/content/ContentOverview.java
+++ b/src/main/java/com/vispana/api/model/content/ContentOverview.java
@@ -6,4 +6,5 @@ public record ContentOverview(
     int partitionGroups,
     int searchableCopies,
     int redundancy,
+    int notYetConverged,
     Map<GroupKey, Integer> groupNodeCount) {}

--- a/src/main/java/com/vispana/schemagen/JSONSchemaGenerator.java
+++ b/src/main/java/com/vispana/schemagen/JSONSchemaGenerator.java
@@ -14,7 +14,7 @@ import java.net.URL;
 public class JSONSchemaGenerator {
   public static void main(String[] args) throws IOException {
     var jsonMapper = new JSONSchemaGenerator();
-    var application = jsonMapper.getResource("container-components.json");
+    var application = jsonMapper.getResource("metrics.json");
     jsonMapper.toSchema(application);
   }
 

--- a/src/main/java/com/vispana/vespa/state/helpers/MetricsFetcher.java
+++ b/src/main/java/com/vispana/vespa/state/helpers/MetricsFetcher.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 
 public class MetricsFetcher {
   public static Map<String, MetricsNode> fetchMetrics(String configHost) {
-    var metricsUrl = configHost + "metrics/v2/values";
+    var metricsUrl = configHost + "metrics/v2/values?consumer=vespa";
     return requestGet(metricsUrl, MetricsSchema.class).getNodes().stream()
         .map(metricsNode -> Map.entry(metricsNode.getHostname(), metricsNode))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/src/main/java/com/vispana/vespa/state/helpers/SystemMetrics.java
+++ b/src/main/java/com/vispana/vespa/state/helpers/SystemMetrics.java
@@ -8,6 +8,7 @@ public class SystemMetrics {
     var cpuUtil = 0d;
     var memoryUsage = 0d;
     var diskUsage = 0d;
+    var notYetConverged = 0;
 
     for (var services : hostMetrics.getServices()) {
       for (var metric : services.getMetrics()) {
@@ -21,9 +22,12 @@ public class SystemMetrics {
         if (values.getCpuUtil() != null) {
           cpuUtil += values.getCpuUtil();
         }
+        if (values.getClusterControllerNodesNotConvergedMax() != null) {
+          notYetConverged += values.getClusterControllerNodesNotConvergedMax().intValue();
+        }
       }
     }
 
-    return new HostMetrics(cpuUtil, memoryUsage * 100, diskUsage * 100);
+    return new HostMetrics(cpuUtil, memoryUsage * 100, diskUsage * 100, notYetConverged);
   }
 }

--- a/src/main/js/components/simple-grid/enhanced-grid.js
+++ b/src/main/js/components/simple-grid/enhanced-grid.js
@@ -397,6 +397,21 @@ function EnhancedGrid({
                 sortable: false,
             },
             {
+                name: <HeaderComponent title="Not Yet Converged" onHeaderClick={onHeaderClick} />,
+                selector: row => row.hostMetrics?.notYetConverged || 0,
+                cell: row => (
+                    <p className="overflow-ellipsis overflow-hidden text-xs text-gray-300 text-center">
+                        {row.hostMetrics?.notYetConverged || 0}
+                    </p>
+                ),
+                grow: 0.5,  // Smaller flex growth since it's just a number
+                minWidth: '100px',
+                maxWidth: '150px',  // Prevent it from taking too much space
+                center: true,
+                wrap: true,
+                sortable: false,
+            },
+            {
                 name: <HeaderComponent title="Hosts" onHeaderClick={onHeaderClick} />,
                 selector: row => row.host?.hostname || '',
                 cell: row => (

--- a/src/main/js/routes/content/content.js
+++ b/src/main/js/routes/content/content.js
@@ -90,6 +90,8 @@ function Content() {
                             <span>Searchable copies: </span> <span className="text-gray-400">{overview.searchableCopies}</span>
                             {' | '}
                             <span>Redundancy: </span> <span className="text-gray-400">{overview.redundancy}</span>
+                            {' | '}
+                            <span>Not Yet Converged: </span> <span className="text-gray-400">{overview.notYetConverged}</span>
                         </p>
                         <p className="mt-2 text-xs">
                             <span className="font-extrabold text-yellow-400">Groups</span>

--- a/src/main/js/routes/content/enhanced-content.js
+++ b/src/main/js/routes/content/enhanced-content.js
@@ -48,6 +48,8 @@ function EnhancedContent() {
                             <span>Searchable copies: </span> <span className="text-gray-400">{overview.searchableCopies}</span>
                             {' | '}
                             <span>Redundancy: </span> <span className="text-gray-400">{overview.redundancy}</span>
+                            {' | '}
+                            <span>Not Yet Converged: </span> <span className="text-gray-400">{overview.notYetConverged}</span>
                         </p>
                         <p className="mt-2 text-xs">
                             <span className="font-extrabold text-yellow-400">Groups</span>

--- a/src/main/resources/json/data/metrics.json
+++ b/src/main/resources/json/data/metrics.json
@@ -1,3488 +1,12 @@
 {
   "nodes": [
     {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277292,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 72088428544,
-                "memory_rss": 67927318528,
-                "cpu": 61.8232067333864,
-                "cpu_util": 1.9319752104183
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.25,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 8,
-                "content.proton.documentdb.documents.ready.last": 8,
-                "content.proton.documentdb.documents.total.last": 8,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10969968,
-                "content.proton.documentdb.disk_usage.last": 3599507,
-                "content.proton.transactionlog.disk_usage.last": 2720059
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001282965477,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000332406204
-              },
-              "dimensions": {
-                "rankProfile": "sparse_def_linear",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.1964212812933,
-                "content.proton.resource_usage.memory.average": 0.5019150743319,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.001524822335,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006832626185,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2592.433333
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 16573,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10350344,
-                "content.proton.documentdb.documents.ready.last": 10350344,
-                "content.proton.documentdb.documents.total.last": 10350344,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 67050664944,
-                "content.proton.documentdb.disk_usage.last": 14765559242,
-                "content.proton.transactionlog.disk_usage.last": 3171862822
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002636736661,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.002176729083
-              },
-              "dimensions": {
-                "rankProfile": "sparse_abc_linear",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277292,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 426512384,
-                "memory_rss": 215687168,
-                "cpu": 11.7918010133579,
-                "cpu_util": 0.3684937816674
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277292,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 979816448,
-                "memory_rss": 317116416,
-                "cpu": 0.4689920857586,
-                "cpu_util": 0.01465600268
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0050083472454
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 2
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 52597861.333333336
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277292,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277292,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 16773120,
-                "cpu": 0.2847451949248,
-                "cpu_util": 0.0088982873414
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.qrserver",
-          "timestamp": 1699277284,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 29428559872,
-                "memory_rss": 21754630144,
-                "cpu": 67.7128147987661,
-                "cpu_util": 4.2320509249229
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "degraded_queries.rate": 1.6666666666667
-              },
-              "dimensions": {
-                "reason": "match_phase",
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "failed_queries.rate": 0,
-                "hits_per_query.average": 19.1250256620817,
-                "queries.rate": 162.3833333333333,
-                "query_latency.average": 3.6956437074523,
-                "query_latency.95percentile": 9.0546875,
-                "query_latency.99percentile": 24.9921875,
-                "totalhits_per_query.average": 250.063641962636
-              },
-              "dimensions": {
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.8480801335559
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "ConcurrentMarkSweep",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 10556992500
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 162.2333333333333
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.4xx.rate": 0
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 18.6666666666667
-              },
-              "dimensions": {
-                "gcName": "ParNew",
-                "serviceId": "qrserver"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277284,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 976433152,
-                "memory_rss": 317382656,
-                "cpu": 0.7923488811167,
-                "cpu_util": 0.0495218050698
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0066777963272
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 2
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 65984734.666666664
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277284,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277284,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129789952,
-                "memory_rss": 18673664,
-                "cpu": 0.4787107823413,
-                "cpu_util": 0.0299194238963
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 72811610112,
-                "memory_rss": 67780874240,
-                "cpu": 64.3529627015866,
-                "cpu_util": 2.0110300844246
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.216666,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 8,
-                "content.proton.documentdb.documents.ready.last": 8,
-                "content.proton.documentdb.documents.total.last": 8,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10998328,
-                "content.proton.documentdb.disk_usage.last": 3603960,
-                "content.proton.transactionlog.disk_usage.last": 2764590
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001228365172,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000320327736
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "sparse_def_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.1946646196216,
-                "content.proton.resource_usage.memory.average": 0.4991960021005,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0016438809402,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006963147195,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2613.2
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 18459,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10348585,
-                "content.proton.documentdb.documents.ready.last": 10348585,
-                "content.proton.documentdb.documents.total.last": 10348585,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66870877193,
-                "content.proton.documentdb.disk_usage.last": 14554341019,
-                "content.proton.transactionlog.disk_usage.last": 3115960324
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002569471982,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0023898035324
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "sparse_abc_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 441192448,
-                "memory_rss": 228712448,
-                "cpu": 11.2412765623775,
-                "cpu_util": 0.3512898925743
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 972333056,
-                "memory_rss": 317452288,
-                "cpu": 0.5185707938002,
-                "cpu_util": 0.0162053373063
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0083333333333
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0.6666666666667
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 59447541.333333336
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 18419712,
-                "cpu": 0.284377532084,
-                "cpu_util": 0.0088867978776
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277282,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 72791019520,
-                "memory_rss": 67771441152,
-                "cpu": 61.3081298093008,
-                "cpu_util": 1.9158790565406
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.3,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10,
-                "content.proton.documentdb.documents.ready.last": 10,
-                "content.proton.documentdb.documents.total.last": 10,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10982384,
-                "content.proton.documentdb.disk_usage.last": 3458479,
-                "content.proton.transactionlog.disk_usage.last": 2591930
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.000113311611,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000285371513
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "sparse_def_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.1947342858982,
-                "content.proton.resource_usage.memory.average": 0.498732232913,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0015180206461,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006084920816,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2564.016666
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 17527.6,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10336781,
-                "content.proton.documentdb.documents.ready.last": 10336781,
-                "content.proton.documentdb.documents.total.last": 10336781,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66888667772,
-                "content.proton.documentdb.disk_usage.last": 14542887778,
-                "content.proton.transactionlog.disk_usage.last": 3191366209
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002324318549,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0022258139949
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "sparse_abc_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277282,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 439095296,
-                "memory_rss": 228454400,
-                "cpu": 11.2077617932419,
-                "cpu_util": 0.3502425560388
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277282,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 979861504,
-                "memory_rss": 307916800,
-                "cpu": 0.5687520910003,
-                "cpu_util": 0.0177735028438
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0033333333333
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 2
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 58816216
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277282,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277282,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 16711680,
-                "cpu": 0.3011040481766,
-                "cpu_util": 0.0094095015055
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 72806244352,
-                "memory_rss": 67642269696,
-                "cpu": 62.118403809305,
-                "cpu_util": 1.9412001190408
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.333333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 8,
-                "content.proton.documentdb.documents.ready.last": 8,
-                "content.proton.documentdb.documents.total.last": 8,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10988952,
-                "content.proton.documentdb.disk_usage.last": 4014854,
-                "content.proton.transactionlog.disk_usage.last": 3106225
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001347785338,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000348006774
-              },
-              "dimensions": {
-                "rankProfile": "sparse_def_linear",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.1957891767318,
-                "content.proton.resource_usage.memory.average": 0.4956166009067,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0016741661988,
-                "content.proton.search_protocol.docsum.latency.average": 0.0007102900643,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2564.566666
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 18533.1,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10318600,
-                "content.proton.documentdb.documents.ready.last": 10318600,
-                "content.proton.documentdb.documents.total.last": 10318600,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66571526021,
-                "content.proton.documentdb.disk_usage.last": 14742162750,
-                "content.proton.transactionlog.disk_usage.last": 3181909978
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002749340572,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0024088533102
-              },
-              "dimensions": {
-                "rankProfile": "sparse_abc_linear",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 413929472,
-                "memory_rss": 203026432,
-                "cpu": 10.8932757621482,
-                "cpu_util": 0.3404148675671
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 981286912,
-                "memory_rss": 318664704,
-                "cpu": 0.4511019103957,
-                "cpu_util": 0.0140969346999
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0066666666667
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.6666666666667
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 62904206.666666664
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 18415616,
-                "cpu": 0.3341495632561,
-                "cpu_util": 0.0104421738518
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.qrserver",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 29431701504,
-                "memory_rss": 21619339264,
-                "cpu": 70.4258194987567,
-                "cpu_util": 4.4016137186723
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "degraded_queries.rate": 1.6333333333333
-              },
-              "dimensions": {
-                "reason": "match_phase",
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "failed_queries.rate": 0,
-                "hits_per_query.average": 19.1497304445123,
-                "queries.rate": 163.8833333333333,
-                "query_latency.average": 3.6539196854847,
-                "query_latency.95percentile": 9.4296875,
-                "query_latency.99percentile": 25.1171875,
-                "totalhits_per_query.average": 246.8501678364358
-              },
-              "dimensions": {
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.779632721202
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "ConcurrentMarkSweep",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 10518895392
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 163.85
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.4xx.rate": 0
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 18
-              },
-              "dimensions": {
-                "gcName": "ParNew",
-                "serviceId": "qrserver"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 981147648,
-                "memory_rss": 308494336,
-                "cpu": 0.6768538676627,
-                "cpu_util": 0.0423033667289
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.5
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 54446726.666666664
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 130297856,
-                "memory_rss": 17162240,
-                "cpu": 0.5778020821511,
-                "cpu_util": 0.0361126301344
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 73396432896,
-                "memory_rss": 68519178240,
-                "cpu": 65.3703500264181,
-                "cpu_util": 2.0428234383256
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.233333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 12,
-                "content.proton.documentdb.documents.ready.last": 12,
-                "content.proton.documentdb.documents.total.last": 12,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10989376,
-                "content.proton.documentdb.disk_usage.last": 3555704,
-                "content.proton.transactionlog.disk_usage.last": 2652152
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001193049275,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000305542362
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "sparse_def_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.3141649414641,
-                "content.proton.resource_usage.memory.average": 0.498080501604,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0016336570663,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006606026264,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2743.466666
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 17617.233333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10295370,
-                "content.proton.documentdb.documents.ready.last": 10295370,
-                "content.proton.documentdb.documents.total.last": 10295370,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 67475267100,
-                "content.proton.documentdb.disk_usage.last": 14938004367,
-                "content.proton.transactionlog.disk_usage.last": 3140320787
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002476559156,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0023881231709
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "sparse_abc_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 474746880,
-                "memory_rss": 263794688,
-                "cpu": 10.8978483654797,
-                "cpu_util": 0.3405577614212
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 974614528,
-                "memory_rss": 324313088,
-                "cpu": 0.5022049938009,
-                "cpu_util": 0.0156939060563
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0016694490818
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 60918654.666666664
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129875968,
-                "memory_rss": 18702336,
-                "cpu": 0.2678426633605,
-                "cpu_util": 0.00837008323
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277294,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 71612735488,
-                "memory_rss": 67636568064,
-                "cpu": 68.5259964431426,
-                "cpu_util": 2.1414373888482
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.25,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 11,
-                "content.proton.documentdb.documents.ready.last": 11,
-                "content.proton.documentdb.documents.total.last": 11,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10933664,
-                "content.proton.documentdb.disk_usage.last": 3530409,
-                "content.proton.transactionlog.disk_usage.last": 2624008
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001250673015,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.000031023659
-              },
-              "dimensions": {
-                "rankProfile": "sparse_def_linear",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.1927215587038,
-                "content.proton.resource_usage.memory.average": 0.4998146417249,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0015744411372,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006815071796,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2822.533333
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 18942.583333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10347493,
-                "content.proton.documentdb.documents.ready.last": 10347493,
-                "content.proton.documentdb.documents.total.last": 10347493,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66987229042,
-                "content.proton.documentdb.disk_usage.last": 14455616138,
-                "content.proton.transactionlog.disk_usage.last": 3110766963
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002691839241,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0022557181163
-              },
-              "dimensions": {
-                "rankProfile": "sparse_abc_linear",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277294,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 451678208,
-                "memory_rss": 241250304,
-                "cpu": 11.415420023015,
-                "cpu_util": 0.3567318757192
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277294,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 985276416,
-                "memory_rss": 311160832,
-                "cpu": 0.485406423266,
-                "cpu_util": 0.0151689507271
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0050083472454
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.3333333333333
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 47913889.333333336
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277294,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277294,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129855488,
-                "memory_rss": 16850944,
-                "cpu": 0.3012867454755,
-                "cpu_util": 0.0094152107961
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277300,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 72834158592,
-                "memory_rss": 67248885760,
-                "cpu": 62.4355949846474,
-                "cpu_util": 1.9511123432702
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.2,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 9,
-                "content.proton.documentdb.documents.ready.last": 9,
-                "content.proton.documentdb.documents.total.last": 9,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10977512,
-                "content.proton.documentdb.disk_usage.last": 3689575,
-                "content.proton.transactionlog.disk_usage.last": 2818448
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001198181687,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000306301097
-              },
-              "dimensions": {
-                "rankProfile": "sparse_def_linear",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.1969664020197,
-                "content.proton.resource_usage.memory.average": 0.4940682087661,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0016055586599,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006396533667,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2645.666666
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 18947.533333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10296798,
-                "content.proton.documentdb.documents.ready.last": 10296798,
-                "content.proton.documentdb.documents.total.last": 10296798,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 67105220264,
-                "content.proton.documentdb.disk_usage.last": 14726052878,
-                "content.proton.transactionlog.disk_usage.last": 3165076421
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002519420813,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0023184402743
-              },
-              "dimensions": {
-                "rankProfile": "sparse_abc_linear",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277300,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 436998144,
-                "memory_rss": 225529856,
-                "cpu": 10.8634587520204,
-                "cpu_util": 0.3394830860006
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277300,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 977072128,
-                "memory_rss": 322031616,
-                "cpu": 0.4519466661087,
-                "cpu_util": 0.0141233333159
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.008347245409
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.6666666666667
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 60383886.666666664
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277300,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277300,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 16674816,
-                "cpu": 0.3012977774058,
-                "cpu_util": 0.0094155555439
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277285,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 72160518144,
-                "memory_rss": 67813756928,
-                "cpu": 63.4832103724207,
-                "cpu_util": 1.9838503241381
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.266666,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 9,
-                "content.proton.documentdb.documents.ready.last": 9,
-                "content.proton.documentdb.documents.total.last": 9,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 11013312,
-                "content.proton.documentdb.disk_usage.last": 3632858,
-                "content.proton.transactionlog.disk_usage.last": 2687398
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001199380192,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000299569914
-              },
-              "dimensions": {
-                "rankProfile": "sparse_def_linear",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.1960925036868,
-                "content.proton.resource_usage.memory.average": 0.4969710161084,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0015875363115,
-                "content.proton.search_protocol.docsum.latency.average": 0.000627300068,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2830.2
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 18692.566666,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10338680,
-                "content.proton.documentdb.documents.ready.last": 10338680,
-                "content.proton.documentdb.documents.total.last": 10338680,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66803959300,
-                "content.proton.documentdb.disk_usage.last": 14637869313,
-                "content.proton.transactionlog.disk_usage.last": 3175328032
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002454552724,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0022832253522
-              },
-              "dimensions": {
-                "rankProfile": "sparse_abc_linear",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277285,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 430706688,
-                "memory_rss": 220254208,
-                "cpu": 11.5378612085202,
-                "cpu_util": 0.3605581627663
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277285,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 985063424,
-                "memory_rss": 327806976,
-                "cpu": 0.5327728119374,
-                "cpu_util": 0.016649150373
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0033388981636
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0.5
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 54568088
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277285,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277285,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 18542592,
-                "cpu": 0.2996847067148,
-                "cpu_util": 0.0093651470848
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277295,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 72594468864,
-                "memory_rss": 67759783936,
-                "cpu": 56.4863450873705,
-                "cpu_util": 1.7651982839803
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.233333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10,
-                "content.proton.documentdb.documents.ready.last": 10,
-                "content.proton.documentdb.documents.total.last": 10,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 11195048,
-                "content.proton.documentdb.disk_usage.last": 4351193,
-                "content.proton.transactionlog.disk_usage.last": 3385109
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001237967624,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000319430618
-              },
-              "dimensions": {
-                "rankProfile": "sparse_def_linear",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.2054537747571,
-                "content.proton.resource_usage.memory.average": 0.4986457818518,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0016366305522,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006430233187,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2387.066666
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 16059.433333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10333350,
-                "content.proton.documentdb.documents.ready.last": 10333350,
-                "content.proton.documentdb.documents.total.last": 10333350,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66914791929,
-                "content.proton.documentdb.disk_usage.last": 14662927863,
-                "content.proton.transactionlog.disk_usage.last": 6104383889
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002516622073,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.002365628855
-              },
-              "dimensions": {
-                "rankProfile": "sparse_abc_linear",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277295,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 460066816,
-                "memory_rss": 248582144,
-                "cpu": 11.4847755571832,
-                "cpu_util": 0.358899236162
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277295,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 981352448,
-                "memory_rss": 298000384,
-                "cpu": 0.5692162812598,
-                "cpu_util": 0.0177880087894
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.6666666666667
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.0833333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 38456996
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277295,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277295,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 18345984,
-                "cpu": 0.3013497959611,
-                "cpu_util": 0.0094171811238
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 73435156480,
-                "memory_rss": 68393226240,
-                "cpu": 67.8213841993715,
-                "cpu_util": 2.1194182562304
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.333333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 11,
-                "content.proton.documentdb.documents.ready.last": 11,
-                "content.proton.documentdb.documents.total.last": 11,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 11056592,
-                "content.proton.documentdb.disk_usage.last": 3980493,
-                "content.proton.transactionlog.disk_usage.last": 3020751
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001298606255,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000321621732
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "sparse_def_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.3016775168517,
-                "content.proton.resource_usage.memory.average": 0.4983564298772,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0016357529363,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006574894707,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2724.566666
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 17706.616666,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10323897,
-                "content.proton.documentdb.documents.ready.last": 10323897,
-                "content.proton.documentdb.documents.total.last": 10323897,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 67108882620,
-                "content.proton.documentdb.disk_usage.last": 14914028888,
-                "content.proton.transactionlog.disk_usage.last": 3148502656
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002655090589,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0023506600284
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "sparse_abc_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 428609536,
-                "memory_rss": 217632768,
-                "cpu": 12.4116474039736,
-                "cpu_util": 0.3878639813742
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 981856256,
-                "memory_rss": 320544768,
-                "cpu": 0.5679623307337,
-                "cpu_util": 0.0177488228354
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.008347245409
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.3333333333333
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 60487321.333333336
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 18526208,
-                "cpu": 0.3006859398002,
-                "cpu_util": 0.0093964356188
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
+      "hostname": "323d223c6962",
+      "role": "hosts/323d223c6962",
       "services": [
         {
           "name": "vespa.container",
-          "timestamp": 1699277301,
+          "timestamp": 1760044773,
           "status": {
             "code": "up",
             "description": "Data collected successfully"
@@ -3490,10 +14,10 @@
           "metrics": [
             {
               "values": {
-                "memory_virt": 29777395712,
-                "memory_rss": 25281224704,
-                "cpu": 5.0061216161067,
-                "cpu_util": 0.3128826010067
+                "memory_virt": 3847352320,
+                "memory_rss": 1563971584,
+                "cpu": 3.8150484170465,
+                "cpu_util": 0.3468225833679
               },
               "dimensions": {
                 "serviceId": "container"
@@ -3501,224 +25,326 @@
             },
             {
               "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "ConcurrentMarkSweep",
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "feed.operations.rate": 0
-              },
-              "dimensions": {
-                "status": "OK",
-                "api": "vespa.http.server",
-                "operation": "PUT",
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
+                "http.status.2xx.rate": 0.0666677777963
               },
               "dimensions": {
                 "httpMethod": "GET",
+                "statusCode": "200",
+                "protocol": "http1",
+                "requestType": "monitoring",
                 "serviceId": "container"
               }
             },
             {
               "values": {
-                "serverActiveThreads.average": 0
+                "serverActiveThreads.sum": 0,
+                "serverActiveThreads.count": 597,
+                "serverActiveThreads.last": 0,
+                "serverActiveThreads.max": 0,
+                "serverActiveThreads.min": 0,
+                "serverThreadPoolSize.last": 44,
+                "serverThreadPoolSize.max": 44,
+                "jdisc.thread_pool.work_queue.capacity.sum": 298500,
+                "jdisc.thread_pool.work_queue.capacity.count": 597,
+                "jdisc.thread_pool.work_queue.capacity.last": 500,
+                "jdisc.thread_pool.work_queue.capacity.max": 500,
+                "jdisc.thread_pool.work_queue.capacity.min": 500,
+                "jdisc.thread_pool.work_queue.size.sum": 0,
+                "jdisc.thread_pool.work_queue.size.count": 597,
+                "jdisc.thread_pool.work_queue.size.last": 0,
+                "jdisc.thread_pool.work_queue.size.max": 0,
+                "jdisc.thread_pool.work_queue.size.min": 0,
+                "jdisc.thread_pool.max_allowed_size.sum": 26268,
+                "jdisc.thread_pool.max_allowed_size.count": 597,
+                "jdisc.thread_pool.max_allowed_size.last": 44,
+                "jdisc.thread_pool.max_allowed_size.max": 44,
+                "jdisc.thread_pool.max_allowed_size.min": 44,
+                "jdisc.thread_pool.active_threads.sum": 0,
+                "jdisc.thread_pool.active_threads.count": 597,
+                "jdisc.thread_pool.active_threads.last": 0,
+                "jdisc.thread_pool.active_threads.max": 0,
+                "jdisc.thread_pool.active_threads.min": 0,
+                "jdisc.thread_pool.size.sum": 26268,
+                "jdisc.thread_pool.size.count": 597,
+                "jdisc.thread_pool.size.last": 44,
+                "jdisc.thread_pool.size.max": 44,
+                "jdisc.thread_pool.size.min": 44
               },
               "dimensions": {
+                "threadpool": "feedapi-handler",
                 "serviceId": "container"
               }
             },
             {
               "values": {
-                "feed.operations.rate": 0
-              },
-              "dimensions": {
-                "status": "OK",
-                "api": "vespa.http.server",
-                "operation": "REMOVE",
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "ParNew",
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 19733428798.666668
-              },
-              "dimensions": {
-                "serviceId": "container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277301,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 974852096,
-                "memory_rss": 326139904,
-                "cpu": 0.837144082961,
-                "cpu_util": 0.0523215051851
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0033388981636
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.5
+                "jdisc.gc.ms.average": 0,
+                "jdisc.gc.ms.last": 0,
+                "jdisc.gc.ms.max": 0,
+                "jdisc.gc.count.average": 0,
+                "jdisc.gc.count.last": 0,
+                "jdisc.gc.count.max": 0
               },
               "dimensions": {
                 "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
+                "serviceId": "container"
               }
             },
             {
               "values": {
-                "http.status.2xx.rate": 0.1
+                "serverThreadPoolSize.last": 110,
+                "serverThreadPoolSize.max": 110,
+                "serverActiveThreads.sum": 0,
+                "serverActiveThreads.count": 596,
+                "serverActiveThreads.last": 0,
+                "serverActiveThreads.max": 0,
+                "serverActiveThreads.min": 0,
+                "jdisc.thread_pool.work_queue.size.sum": 0,
+                "jdisc.thread_pool.work_queue.size.count": 596,
+                "jdisc.thread_pool.work_queue.size.last": 0,
+                "jdisc.thread_pool.work_queue.size.max": 0,
+                "jdisc.thread_pool.work_queue.size.min": 0,
+                "jdisc.thread_pool.work_queue.capacity.sum": 2622400,
+                "jdisc.thread_pool.work_queue.capacity.count": 596,
+                "jdisc.thread_pool.work_queue.capacity.last": 4400,
+                "jdisc.thread_pool.work_queue.capacity.max": 4400,
+                "jdisc.thread_pool.work_queue.capacity.min": 4400,
+                "jdisc.thread_pool.max_allowed_size.sum": 65560,
+                "jdisc.thread_pool.max_allowed_size.count": 596,
+                "jdisc.thread_pool.max_allowed_size.last": 110,
+                "jdisc.thread_pool.max_allowed_size.max": 110,
+                "jdisc.thread_pool.max_allowed_size.min": 110,
+                "jdisc.thread_pool.active_threads.sum": 0,
+                "jdisc.thread_pool.active_threads.count": 596,
+                "jdisc.thread_pool.active_threads.last": 0,
+                "jdisc.thread_pool.active_threads.max": 0,
+                "jdisc.thread_pool.active_threads.min": 0,
+                "jdisc.thread_pool.size.sum": 65560,
+                "jdisc.thread_pool.size.count": 596,
+                "jdisc.thread_pool.size.last": 110,
+                "jdisc.thread_pool.size.max": 110,
+                "jdisc.thread_pool.size.min": 110
+              },
+              "dimensions": {
+                "threadpool": "search-handler",
+                "serviceId": "container"
+              }
+            },
+            {
+              "values": {
+                "jdisc.jvm.last": 17
+              },
+              "dimensions": {
+                "vendor": "Red Hat, Inc.",
+                "serviceId": "container"
+              }
+            },
+            {
+              "values": {
+                "http.status.4xx.rate": 0
               },
               "dimensions": {
                 "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
+                "statusCode": "404",
+                "protocol": "http1",
+                "requestType": "read",
+                "serviceId": "container"
               }
             },
             {
               "values": {
-                "jdisc.gc.ms.average": 0
+                "serverBytesSent.sum": 0,
+                "serverBytesSent.count": 2,
+                "jdisc.http.request.uri_length.sum": 34,
+                "jdisc.http.request.uri_length.count": 2,
+                "jdisc.http.request.uri_length.max": 17,
+                "jdisc.http.requests.count": 2,
+                "jdisc.http.requests.rate": 0.0333338888981,
+                "jdisc.http.request.content_size.sum": 0,
+                "jdisc.http.request.content_size.count": 2,
+                "jdisc.http.request.content_size.max": 0
+              },
+              "dimensions": {
+                "serverPort": "8080",
+                "serverName": "SearchServer",
+                "protocol": "HTTP/1.1",
+                "httpMethod": "GET",
+                "serviceId": "container"
+              }
+            },
+            {
+              "values": {
+                "serverActiveThreads.sum": 0,
+                "serverActiveThreads.count": 596,
+                "serverActiveThreads.last": 0,
+                "serverActiveThreads.max": 0,
+                "serverActiveThreads.min": 0,
+                "serverThreadPoolSize.last": 22,
+                "serverThreadPoolSize.max": 22,
+                "jdisc.thread_pool.work_queue.capacity.sum": 524480,
+                "jdisc.thread_pool.work_queue.capacity.count": 596,
+                "jdisc.thread_pool.work_queue.capacity.last": 880,
+                "jdisc.thread_pool.work_queue.capacity.max": 880,
+                "jdisc.thread_pool.work_queue.capacity.min": 880,
+                "jdisc.thread_pool.work_queue.size.sum": 0,
+                "jdisc.thread_pool.work_queue.size.count": 596,
+                "jdisc.thread_pool.work_queue.size.last": 0,
+                "jdisc.thread_pool.work_queue.size.max": 0,
+                "jdisc.thread_pool.work_queue.size.min": 0,
+                "jdisc.thread_pool.max_allowed_size.sum": 13112,
+                "jdisc.thread_pool.max_allowed_size.count": 596,
+                "jdisc.thread_pool.max_allowed_size.last": 22,
+                "jdisc.thread_pool.max_allowed_size.max": 22,
+                "jdisc.thread_pool.max_allowed_size.min": 22,
+                "jdisc.thread_pool.active_threads.sum": 0,
+                "jdisc.thread_pool.active_threads.count": 596,
+                "jdisc.thread_pool.active_threads.last": 0,
+                "jdisc.thread_pool.active_threads.max": 0,
+                "jdisc.thread_pool.active_threads.min": 0,
+                "jdisc.thread_pool.size.sum": 13112,
+                "jdisc.thread_pool.size.count": 596,
+                "jdisc.thread_pool.size.last": 22,
+                "jdisc.thread_pool.size.max": 22,
+                "jdisc.thread_pool.size.min": 22
+              },
+              "dimensions": {
+                "threadpool": "default-handler-common",
+                "serviceId": "container"
+              }
+            },
+            {
+              "values": {
+                "jdisc.http.request.requests_per_connection.average": 1,
+                "jdisc.http.request.requests_per_connection.sum": 0,
+                "jdisc.http.request.requests_per_connection.count": 0,
+                "jdisc.http.request.requests_per_connection.max": 1,
+                "jdisc.http.request.requests_per_connection.min": 1,
+                "serverNumConnections.average": 30,
+                "serverNumConnections.last": 30,
+                "serverNumConnections.max": 30,
+                "serverNumOpenConnections.average": 1,
+                "serverNumOpenConnections.last": 1,
+                "serverNumOpenConnections.max": 1
+              },
+              "dimensions": {
+                "serverName": "SearchServer",
+                "serverPort": "8080",
+                "serviceId": "container"
+              }
+            },
+            {
+              "values": {
+                "mem.native.free.average": 0,
+                "jdisc.http.jetty.threadpool.thread.total.sum": 810,
+                "jdisc.http.jetty.threadpool.thread.total.count": 30,
+                "jdisc.http.jetty.threadpool.thread.total.last": 27,
+                "jdisc.http.jetty.threadpool.thread.total.max": 27,
+                "jdisc.http.jetty.threadpool.thread.total.min": 27,
+                "jdisc.open_file_descriptors.max": 186,
+                "mem.native.used.average": 285212672,
+                "jdisc.tls.capability_checks.failed.rate": 0,
+                "jdisc.deactivated_containers.total.sum": 0,
+                "jdisc.deactivated_containers.total.last": 0,
+                "jdisc.memory_mappings.max": 995,
+                "jdisc.http.jetty.threadpool.thread.max.sum": 810,
+                "jdisc.http.jetty.threadpool.thread.max.count": 30,
+                "jdisc.http.jetty.threadpool.thread.max.last": 27,
+                "jdisc.http.jetty.threadpool.thread.max.max": 27,
+                "jdisc.http.jetty.threadpool.thread.max.min": 27,
+                "jdisc.http.jetty.threadpool.thread.reserved.sum": -30,
+                "jdisc.http.jetty.threadpool.thread.reserved.count": 30,
+                "jdisc.http.jetty.threadpool.thread.reserved.last": -1,
+                "jdisc.http.jetty.threadpool.thread.reserved.max": -1,
+                "jdisc.http.jetty.threadpool.thread.reserved.min": -1,
+                "mem.heap.used.average": 863976466.666667,
+                "mem.heap.used.max": 883962448,
+                "mem.native.total.average": 285212672,
+                "jdisc.tls.capability_checks.succeeded.rate": 0,
+                "mem.direct.count.max": 77,
+                "jdisc.http.jetty.threadpool.queue.size.sum": 0,
+                "jdisc.http.jetty.threadpool.queue.size.count": 30,
+                "jdisc.http.jetty.threadpool.queue.size.last": 0,
+                "jdisc.http.jetty.threadpool.queue.size.max": 0,
+                "jdisc.http.jetty.threadpool.queue.size.min": 0,
+                "mem.direct.free.average": 0,
+                "mem.heap.total.average": 1610612736,
+                "mem.direct.used.average": 1661781,
+                "mem.direct.used.max": 1661781,
+                "jdisc.http.jetty.threadpool.thread.busy.sum": 60,
+                "jdisc.http.jetty.threadpool.thread.busy.count": 30,
+                "jdisc.http.jetty.threadpool.thread.busy.last": 2,
+                "jdisc.http.jetty.threadpool.thread.busy.max": 2,
+                "jdisc.http.jetty.threadpool.thread.busy.min": 2,
+                "mem.direct.total.average": 1661781,
+                "jdisc.http.jetty.threadpool.thread.min.sum": 810,
+                "jdisc.http.jetty.threadpool.thread.min.count": 30,
+                "jdisc.http.jetty.threadpool.thread.min.last": 27,
+                "jdisc.http.jetty.threadpool.thread.min.max": 27,
+                "jdisc.http.jetty.threadpool.thread.min.min": 27,
+                "mem.heap.free.average": 746636269.333333
+              },
+              "dimensions": {
+                "serviceId": "container"
+              }
+            },
+            {
+              "values": {
+                "jdisc.gc.ms.average": 0,
+                "jdisc.gc.ms.last": 0,
+                "jdisc.gc.ms.max": 0,
+                "jdisc.gc.count.average": 0,
+                "jdisc.gc.count.last": 0,
+                "jdisc.gc.count.max": 0
               },
               "dimensions": {
                 "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
+                "serviceId": "container"
               }
             },
             {
               "values": {
-                "mem.heap.free.average": 67512693.33333333
+                "serverActiveThreads.sum": 0,
+                "serverActiveThreads.count": 596,
+                "serverActiveThreads.last": 0,
+                "serverActiveThreads.max": 0,
+                "serverActiveThreads.min": 0,
+                "serverThreadPoolSize.last": 22,
+                "serverThreadPoolSize.max": 22,
+                "jdisc.thread_pool.work_queue.capacity.sum": 655600,
+                "jdisc.thread_pool.work_queue.capacity.count": 596,
+                "jdisc.thread_pool.work_queue.capacity.last": 1100,
+                "jdisc.thread_pool.work_queue.capacity.max": 1100,
+                "jdisc.thread_pool.work_queue.capacity.min": 1100,
+                "jdisc.thread_pool.work_queue.size.sum": 0,
+                "jdisc.thread_pool.work_queue.size.count": 596,
+                "jdisc.thread_pool.work_queue.size.last": 0,
+                "jdisc.thread_pool.work_queue.size.max": 0,
+                "jdisc.thread_pool.work_queue.size.min": 0,
+                "jdisc.thread_pool.max_allowed_size.sum": 655600,
+                "jdisc.thread_pool.max_allowed_size.count": 596,
+                "jdisc.thread_pool.max_allowed_size.last": 1100,
+                "jdisc.thread_pool.max_allowed_size.max": 1100,
+                "jdisc.thread_pool.max_allowed_size.min": 1100,
+                "jdisc.thread_pool.active_threads.sum": 0,
+                "jdisc.thread_pool.active_threads.count": 596,
+                "jdisc.thread_pool.active_threads.last": 0,
+                "jdisc.thread_pool.active_threads.max": 0,
+                "jdisc.thread_pool.active_threads.min": 0,
+                "jdisc.thread_pool.size.sum": 13112,
+                "jdisc.thread_pool.size.count": 596,
+                "jdisc.thread_pool.size.last": 22,
+                "jdisc.thread_pool.size.max": 22,
+                "jdisc.thread_pool.size.min": 22
               },
               "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
+                "threadpool": "default-pool",
+                "serviceId": "container"
               }
             }
           ]
         },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277301,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277301,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129794048,
-                "memory_rss": 18497536,
-                "cpu": 0.686458148028,
-                "cpu_util": 0.0429036342518
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
         {
           "name": "vespa.configserver",
-          "timestamp": 1699277296,
+          "timestamp": 1760044773,
           "status": {
             "code": "up",
             "description": "Data collected successfully"
@@ -3737,36 +363,84 @@
             },
             {
               "values": {
-                "http.status.2xx.rate": 0.1166666666667
+                "jdisc.http.request.requests_per_connection.average": 1.25,
+                "jdisc.http.request.requests_per_connection.sum": 5,
+                "jdisc.http.request.requests_per_connection.count": 4,
+                "jdisc.http.request.requests_per_connection.max": 2,
+                "jdisc.http.request.requests_per_connection.min": 1,
+                "serverNumConnections.average": 240.533333333333,
+                "serverNumConnections.last": 244,
+                "serverNumConnections.max": 246,
+                "serverNumOpenConnections.average": 1.2333333333333,
+                "serverNumOpenConnections.last": 1,
+                "serverNumOpenConnections.max": 2
               },
               "dimensions": {
-                "httpMethod": "GET",
+                "serverName": "configserver",
+                "serverPort": "19071",
                 "serviceId": "configserver"
               }
             },
             {
               "values": {
-                "jdisc.gc.ms.average": 0
+                "handled.latency.sum": 0,
+                "handled.latency.count": 0,
+                "handled.latency.max": 14,
+                "handled.requests.count": 0
               },
               "dimensions": {
-                "gcName": "G1OldGeneration",
+                "handler": "http://*:*/config/v1/*",
+                "endpoint": "localhost:19071",
+                "handler-name": "com.yahoo.vespa.config.server.http.HttpGetConfigHandler",
                 "serviceId": "configserver"
               }
             },
             {
               "values": {
-                "mem.heap.free.average": 257928721.33333334
+                "serverActiveThreads.sum": 1,
+                "serverActiveThreads.count": 597,
+                "serverActiveThreads.last": 0,
+                "serverActiveThreads.max": 1,
+                "serverActiveThreads.min": 0,
+                "serverThreadPoolSize.last": 22,
+                "serverThreadPoolSize.max": 22,
+                "jdisc.thread_pool.work_queue.capacity.sum": 656700,
+                "jdisc.thread_pool.work_queue.capacity.count": 597,
+                "jdisc.thread_pool.work_queue.capacity.last": 1100,
+                "jdisc.thread_pool.work_queue.capacity.max": 1100,
+                "jdisc.thread_pool.work_queue.capacity.min": 1100,
+                "jdisc.thread_pool.work_queue.size.sum": 1,
+                "jdisc.thread_pool.work_queue.size.count": 597,
+                "jdisc.thread_pool.work_queue.size.last": 0,
+                "jdisc.thread_pool.work_queue.size.max": 1,
+                "jdisc.thread_pool.work_queue.size.min": 0,
+                "jdisc.thread_pool.max_allowed_size.sum": 656700,
+                "jdisc.thread_pool.max_allowed_size.count": 597,
+                "jdisc.thread_pool.max_allowed_size.last": 1100,
+                "jdisc.thread_pool.max_allowed_size.max": 1100,
+                "jdisc.thread_pool.max_allowed_size.min": 1100,
+                "jdisc.thread_pool.active_threads.sum": 1,
+                "jdisc.thread_pool.active_threads.count": 597,
+                "jdisc.thread_pool.active_threads.last": 0,
+                "jdisc.thread_pool.active_threads.max": 1,
+                "jdisc.thread_pool.active_threads.min": 0,
+                "jdisc.thread_pool.size.sum": 13134,
+                "jdisc.thread_pool.size.count": 597,
+                "jdisc.thread_pool.size.last": 22,
+                "jdisc.thread_pool.size.max": 22,
+                "jdisc.thread_pool.size.min": 22
               },
               "dimensions": {
+                "threadpool": "default-pool",
                 "serviceId": "configserver"
               }
             },
             {
               "values": {
-                "jdisc.gc.ms.average": 0
+                "jdisc.jvm.last": 17
               },
               "dimensions": {
-                "gcName": "G1YoungGeneration",
+                "vendor": "Red Hat, Inc.",
                 "serviceId": "configserver"
               }
             },
@@ -3776,4984 +450,32 @@
               },
               "dimensions": {
                 "httpMethod": "GET",
+                "statusCode": "200",
+                "protocol": "http1",
+                "requestType": "read",
                 "serviceId": "configserver"
               }
             },
             {
               "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "configserver"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.slobrok",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 122163200,
-                "memory_rss": 17772544,
-                "cpu": 2.2083734158685,
-                "cpu_util": 0.2760466769836
-              },
-              "dimensions": {
-                "serviceId": "slobrok"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "slobrok"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.container-clustercontroller",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 857133056,
-                "memory_rss": 330489856,
-                "cpu": 2.9277677861893,
-                "cpu_util": 0.3659709732737
-              },
-              "dimensions": {
-                "serviceId": "container-clustercontroller"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "container-clustercontroller"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "container-clustercontroller"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "container-clustercontroller"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 47700501.333333336
-              },
-              "dimensions": {
-                "serviceId": "container-clustercontroller"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
+                "http.status.2xx.rate": 0.15
               },
               "dimensions": {
                 "httpMethod": "GET",
-                "serviceId": "container-clustercontroller"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 1001807872,
-                "memory_rss": 337358848,
-                "cpu": 1.137646911205,
-                "cpu_util": 0.1422058639006
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0050083472454
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 4
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 45474834.666666664
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129798144,
-                "memory_rss": 16801792,
-                "cpu": 0.6692040654147,
-                "cpu_util": 0.0836505081768
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277297,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 73650769920,
-                "memory_rss": 68096954368,
-                "cpu": 69.0122393590647,
-                "cpu_util": 2.1566324799708
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.433333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10,
-                "content.proton.documentdb.documents.ready.last": 10,
-                "content.proton.documentdb.documents.total.last": 10,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10890392,
-                "content.proton.documentdb.disk_usage.last": 3351957,
-                "content.proton.transactionlog.disk_usage.last": 2553477
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001568017606,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000411903082
-              },
-              "dimensions": {
-                "rankProfile": "sparse_def_linear",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.1954590950297,
-                "content.proton.resource_usage.memory.average": 0.500127116089,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0019678502948,
-                "content.proton.search_protocol.docsum.latency.average": 0.0008188148799,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2526.75
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 17549.066666,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10352595,
-                "content.proton.documentdb.documents.ready.last": 10352595,
-                "content.proton.documentdb.documents.total.last": 10352595,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 67224794670,
-                "content.proton.documentdb.disk_usage.last": 14434445044,
-                "content.proton.transactionlog.disk_usage.last": 3152094017
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0003209139684,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0027918530008
-              },
-              "dimensions": {
-                "rankProfile": "sparse_abc_linear",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277297,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 426512384,
-                "memory_rss": 215654400,
-                "cpu": 13.4450272710666,
-                "cpu_util": 0.4201571022208
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277297,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 985280512,
-                "memory_rss": 331767808,
-                "cpu": 0.5678645058587,
-                "cpu_util": 0.0177457658081
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0033333333333
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.5
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 50582582.666666664
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277297,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277297,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 16801792,
-                "cpu": 0.367441739085,
-                "cpu_util": 0.0114825543464
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.qrserver",
-          "timestamp": 1699277292,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 29475254272,
-                "memory_rss": 17042079744,
-                "cpu": 75.3156911131532,
-                "cpu_util": 4.7072306945721
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "degraded_queries.rate": 1.8
-              },
-              "dimensions": {
-                "chain": "default",
-                "reason": "match_phase",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "failed_queries.rate": 0,
-                "hits_per_query.average": 19.36867862969,
-                "queries.rate": 163.45,
-                "query_latency.average": 4.0103094345432,
-                "query_latency.95percentile": 9.6171875,
-                "query_latency.99percentile": 28.8671875,
-                "totalhits_per_query.average": 247.6917822185971
-              },
-              "dimensions": {
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.8514190317195
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "ConcurrentMarkSweep",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 14116482806.666666
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 163.5333333333333
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.4xx.rate": 0
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 14.5
-              },
-              "dimensions": {
-                "gcName": "ParNew",
-                "serviceId": "qrserver"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277292,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 983130112,
-                "memory_rss": 312262656,
-                "cpu": 0.9251324199027,
-                "cpu_util": 0.0578207762439
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0033333333333
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 2
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 48835173.333333336
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277292,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277292,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129789952,
-                "memory_rss": 16924672,
-                "cpu": 0.6277684277911,
-                "cpu_util": 0.0392355267369
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.qrserver",
-          "timestamp": 1699277308,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 29429088256,
-                "memory_rss": 21939867648,
-                "cpu": 71.5097654231683,
-                "cpu_util": 4.469360338948
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "degraded_queries.rate": 1.8833333333333
-              },
-              "dimensions": {
-                "chain": "default",
-                "reason": "match_phase",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "failed_queries.rate": 0,
-                "hits_per_query.average": 19.5708123652049,
-                "queries.rate": 162.2833333333333,
-                "query_latency.average": 4.0355139677519,
-                "query_latency.95percentile": 9.9296875,
-                "query_latency.99percentile": 31.9921875,
-                "totalhits_per_query.average": 279.0143781452193
-              },
-              "dimensions": {
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.815
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "ConcurrentMarkSweep",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 10373413413.333334
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 162.35
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.4xx.rate": 0
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 17.1666666666667
-              },
-              "dimensions": {
-                "gcName": "ParNew",
-                "serviceId": "qrserver"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277308,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 980779008,
-                "memory_rss": 311386112,
-                "cpu": 0.6778960421618,
-                "cpu_util": 0.0423685026351
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0050083472454
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0.6666666666667
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 39163970.666666664
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277308,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277308,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 130289664,
-                "memory_rss": 18468864,
-                "cpu": 0.5290895938824,
-                "cpu_util": 0.0330680996177
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.qrserver",
-          "timestamp": 1699277288,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 29456912384,
-                "memory_rss": 21909622784,
-                "cpu": 89.4515284020834,
-                "cpu_util": 5.5907205251302
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "degraded_queries.rate": 0
-              },
-              "dimensions": {
-                "reason": "timeout",
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "degraded_queries.rate": 1.7333333333333
-              },
-              "dimensions": {
-                "reason": "match_phase",
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "failed_queries.rate": 0,
-                "hits_per_query.average": 18.6147867880151,
-                "queries.rate": 162.9833333333333,
-                "query_latency.average": 4.5493962543205,
-                "query_latency.95percentile": 10.3671875,
-                "query_latency.99percentile": 28.4921875,
-                "totalhits_per_query.average": 251.4181409142039
-              },
-              "dimensions": {
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.9415692821369
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "ConcurrentMarkSweep",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 9960428525.333334
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 162.8666666666667
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.4xx.rate": 0
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 24
-              },
-              "dimensions": {
-                "gcName": "ParNew",
-                "serviceId": "qrserver"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277288,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 976113664,
-                "memory_rss": 337788928,
-                "cpu": 0.9132699344607,
-                "cpu_util": 0.0570793709038
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0050083472454
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 51670777.333333336
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277288,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277288,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129982464,
-                "memory_rss": 16789504,
-                "cpu": 0.7338776259059,
-                "cpu_util": 0.0458673516191
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277287,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 71843647488,
-                "memory_rss": 67419234304,
-                "cpu": 63.1037200586691,
-                "cpu_util": 1.9719912518334
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.216666,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 11,
-                "content.proton.documentdb.documents.ready.last": 11,
-                "content.proton.documentdb.documents.total.last": 11,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10935048,
-                "content.proton.documentdb.disk_usage.last": 3726618,
-                "content.proton.transactionlog.disk_usage.last": 2889820
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001097873339,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000268061958
-              },
-              "dimensions": {
-                "rankProfile": "sparse_def_linear",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.1924811937485,
-                "content.proton.resource_usage.memory.average": 0.4982041021136,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0015171456999,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006101129965,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2833.933333
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 19020.45,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10316551,
-                "content.proton.documentdb.documents.ready.last": 10316551,
-                "content.proton.documentdb.documents.total.last": 10316551,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66979591251,
-                "content.proton.documentdb.disk_usage.last": 14566509536,
-                "content.proton.transactionlog.disk_usage.last": 3146466739
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002370602459,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0022071547094
-              },
-              "dimensions": {
-                "rankProfile": "sparse_abc_linear",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277287,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 441192448,
-                "memory_rss": 230248448,
-                "cpu": 10.7232896446971,
-                "cpu_util": 0.3351028013968
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277287,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 976232448,
-                "memory_rss": 297451520,
-                "cpu": 0.4342765276669,
-                "cpu_util": 0.0135711414896
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0066777963272
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.6666666666667
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 47481265.333333336
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277287,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277287,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129785856,
-                "memory_rss": 16891904,
-                "cpu": 0.250544150577,
-                "cpu_util": 0.0078295047055
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.qrserver",
-          "timestamp": 1699277302,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 29437014016,
-                "memory_rss": 16987971584,
-                "cpu": 87.0659596855722,
-                "cpu_util": 5.4416224803483
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "degraded_queries.rate": 1.7166666666667
-              },
-              "dimensions": {
-                "reason": "match_phase",
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "failed_queries.rate": 0,
-                "hits_per_query.average": 18.6815267175573,
-                "queries.rate": 163.75,
-                "query_latency.average": 4.2509808252417,
-                "query_latency.95percentile": 9.7421875,
-                "query_latency.99percentile": 26.2421875,
-                "totalhits_per_query.average": 243.6258524173028
-              },
-              "dimensions": {
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.9333333333333
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "ConcurrentMarkSweep",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 15213063650.666666
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 163.3833333333333
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.4xx.rate": 0
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 27.3333333333333
-              },
-              "dimensions": {
-                "gcName": "ParNew",
-                "serviceId": "qrserver"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277302,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 984588288,
-                "memory_rss": 311074816,
-                "cpu": 0.9077967360581,
-                "cpu_util": 0.0567372960036
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0100166944908
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 3
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 62277064
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277302,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277302,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129982464,
-                "memory_rss": 16732160,
-                "cpu": 0.7592481792486,
-                "cpu_util": 0.047453011203
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 73050636288,
-                "memory_rss": 68401741824,
-                "cpu": 68.839558435979,
-                "cpu_util": 2.1512362011243
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.033333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 7,
-                "content.proton.documentdb.documents.ready.last": 7,
-                "content.proton.documentdb.documents.total.last": 7,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10902472,
-                "content.proton.documentdb.disk_usage.last": 3392126,
-                "content.proton.transactionlog.disk_usage.last": 2504017
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001708376845,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.000044594619
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "sparse_def_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.302387316849,
-                "content.proton.resource_usage.memory.average": 0.4974853740743,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0017896969575,
-                "content.proton.search_protocol.docsum.latency.average": 0.0008899296636,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2377.933333
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 15314.316666,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10323702,
-                "content.proton.documentdb.documents.ready.last": 10323702,
-                "content.proton.documentdb.documents.total.last": 10323702,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66821033273,
-                "content.proton.documentdb.disk_usage.last": 14659953847,
-                "content.proton.transactionlog.disk_usage.last": 3150859126
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.000335145954,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.002443258734
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "sparse_abc_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 416026624,
-                "memory_rss": 205094912,
-                "cpu": 15.6590715000498,
-                "cpu_util": 0.4893459843766
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 970629120,
-                "memory_rss": 313266176,
-                "cpu": 0.6873896482891,
-                "cpu_util": 0.021480926509
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0100166944908
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0.6666666666667
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 36355681.333333336
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 18583552,
-                "cpu": 0.4694368329779,
-                "cpu_util": 0.0146699010306
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.qrserver",
-          "timestamp": 1699277307,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 29431726080,
-                "memory_rss": 21705998336,
-                "cpu": 91.7245323094518,
-                "cpu_util": 5.7327832693407
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "degraded_queries.rate": 0
-              },
-              "dimensions": {
-                "chain": "default",
-                "reason": "timeout",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "degraded_queries.rate": 1.65
-              },
-              "dimensions": {
-                "chain": "default",
-                "reason": "match_phase",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "failed_queries.rate": 0,
-                "hits_per_query.average": 18.872318587704,
-                "queries.rate": 162.4166666666667,
-                "query_latency.average": 4.5569402670635,
-                "query_latency.95percentile": 10.1796875,
-                "query_latency.99percentile": 28.3671875,
-                "totalhits_per_query.average": 254.3200246330699
-              },
-              "dimensions": {
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.8948247078464
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "ConcurrentMarkSweep",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 9601326929.333334
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 162.9833333333333
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.4xx.rate": 0
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 15.8333333333333
-              },
-              "dimensions": {
-                "gcName": "ParNew",
-                "serviceId": "qrserver"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277307,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 971759616,
-                "memory_rss": 294821888,
-                "cpu": 1.1110203414754,
-                "cpu_util": 0.0694387713422
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.008347245409
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 3.3333333333333
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 58610241.333333336
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277307,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277307,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129957888,
-                "memory_rss": 16752640,
-                "cpu": 0.8005881872396,
-                "cpu_util": 0.0500367617025
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 72723173376,
-                "memory_rss": 68001357824,
-                "cpu": 79.6634645570415,
-                "cpu_util": 2.4894832674075
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.083333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 9,
-                "content.proton.documentdb.documents.ready.last": 9,
-                "content.proton.documentdb.documents.total.last": 9,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10951360,
-                "content.proton.documentdb.disk_usage.last": 3594820,
-                "content.proton.transactionlog.disk_usage.last": 2733228
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001684059041,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000419845412
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "sparse_def_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.3004918707383,
-                "content.proton.resource_usage.memory.average": 0.4954192755262,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0020715916656,
-                "content.proton.search_protocol.docsum.latency.average": 0.000902137503,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2336.166666
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 14696.716666,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10325116,
-                "content.proton.documentdb.documents.ready.last": 10325116,
-                "content.proton.documentdb.documents.total.last": 10325116,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66947917260,
-                "content.proton.documentdb.disk_usage.last": 14856557125,
-                "content.proton.transactionlog.disk_usage.last": 3106738655
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0003594048114,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0029249175989
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "sparse_abc_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 420220928,
-                "memory_rss": 209321984,
-                "cpu": 13.7795357987485,
-                "cpu_util": 0.4306104937109
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 974544896,
-                "memory_rss": 323780608,
-                "cpu": 0.7366945019987,
-                "cpu_util": 0.0230217031875
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0066777963272
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 2
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 62931228
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 16773120,
-                "cpu": 0.385090307863,
-                "cpu_util": 0.0120340721207
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277291,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 72006774784,
-                "memory_rss": 67139997696,
-                "cpu": 64.5672008574939,
-                "cpu_util": 2.0177250267967
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.3,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 8,
-                "content.proton.documentdb.documents.ready.last": 8,
-                "content.proton.documentdb.documents.total.last": 8,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10839016,
-                "content.proton.documentdb.disk_usage.last": 3749958,
-                "content.proton.transactionlog.disk_usage.last": 2900074
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001134880288,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000279826398
-              },
-              "dimensions": {
-                "rankProfile": "sparse_def_linear",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.1960155401637,
-                "content.proton.resource_usage.memory.average": 0.4960909454255,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0016988981343,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006889051947,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2561
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 17355.233333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10323760,
-                "content.proton.documentdb.documents.ready.last": 10323760,
-                "content.proton.documentdb.documents.total.last": 10323760,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66901723820,
-                "content.proton.documentdb.disk_usage.last": 14832297906,
-                "content.proton.transactionlog.disk_usage.last": 3148490826
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002556012836,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0025164998999
-              },
-              "dimensions": {
-                "rankProfile": "sparse_abc_linear",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277291,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 487329792,
-                "memory_rss": 275476480,
-                "cpu": 10.5576324801966,
-                "cpu_util": 0.3299260150061
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277291,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 981069824,
-                "memory_rss": 312090624,
-                "cpu": 0.4852160727824,
-                "cpu_util": 0.0151630022745
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.01
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.3333333333333
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 53701640
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277291,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277291,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 16736256,
-                "cpu": 0.2509738307495,
-                "cpu_util": 0.0078429322109
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 73413890048,
-                "memory_rss": 68395896832,
-                "cpu": 67.9308328460446,
-                "cpu_util": 2.1228385264389
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.116666,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 13,
-                "content.proton.documentdb.documents.ready.last": 13,
-                "content.proton.documentdb.documents.total.last": 13,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 11194512,
-                "content.proton.documentdb.disk_usage.last": 4708318,
-                "content.proton.transactionlog.disk_usage.last": 3666290
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001365926506,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000342171875
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "sparse_def_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.3029652576802,
-                "content.proton.resource_usage.memory.average": 0.4970522400158,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0018217191957,
-                "content.proton.search_protocol.docsum.latency.average": 0.0007710253751,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2356.9
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 15410.25,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10338626,
-                "content.proton.documentdb.documents.ready.last": 10338626,
-                "content.proton.documentdb.documents.total.last": 10338626,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66988903998,
-                "content.proton.documentdb.disk_usage.last": 14873844212,
-                "content.proton.transactionlog.disk_usage.last": 3170050699
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002894240497,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0026172756411
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "sparse_abc_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 478941184,
-                "memory_rss": 267321344,
-                "cpu": 12.7140589758583,
-                "cpu_util": 0.3973143429956
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 973598720,
-                "memory_rss": 303984640,
-                "cpu": 0.5847464706374,
-                "cpu_util": 0.0182733272074
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0066777963272
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.5
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 31688750.666666668
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 18288640,
-                "cpu": 0.2673126722914,
-                "cpu_util": 0.0083535210091
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 72817954816,
-                "memory_rss": 66974003200,
-                "cpu": 69.324366085786,
-                "cpu_util": 2.1663864401808
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.283333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 14,
-                "content.proton.documentdb.documents.ready.last": 14,
-                "content.proton.documentdb.documents.total.last": 14,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 11033104,
-                "content.proton.documentdb.disk_usage.last": 3323730,
-                "content.proton.transactionlog.disk_usage.last": 2434496
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.000149531776,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000384111279
-              },
-              "dimensions": {
-                "rankProfile": "sparse_def_linear",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.194749913165,
-                "content.proton.resource_usage.memory.average": 0.4946969107003,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0016409086799,
-                "content.proton.search_protocol.docsum.latency.average": 0.0007668180443,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2622.433333
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 16770.383333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10315041,
-                "content.proton.documentdb.documents.ready.last": 10315041,
-                "content.proton.documentdb.documents.total.last": 10315041,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 67053243931,
-                "content.proton.documentdb.disk_usage.last": 14622226189,
-                "content.proton.transactionlog.disk_usage.last": 3150279426
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002967470438,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0022883528704
-              },
-              "dimensions": {
-                "rankProfile": "sparse_abc_linear",
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 405540864,
-                "memory_rss": 194846720,
-                "cpu": 14.2135063928304,
-                "cpu_util": 0.4441720747759
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 983396352,
-                "memory_rss": 329359360,
-                "cpu": 0.6704484147562,
-                "cpu_util": 0.0209515129611
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0066777963272
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.6666666666667
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 59927844
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 16531456,
-                "cpu": 0.4357914695915,
-                "cpu_util": 0.0136184834247
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277292,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 71576764416,
-                "memory_rss": 67145314304,
-                "cpu": 64.1821816164851,
-                "cpu_util": 2.0056931755152
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.216666,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 9,
-                "content.proton.documentdb.documents.ready.last": 9,
-                "content.proton.documentdb.documents.total.last": 9,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10950272,
-                "content.proton.documentdb.disk_usage.last": 3110813,
-                "content.proton.transactionlog.disk_usage.last": 2373443
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001072748038,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000263589605
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "sparse_def_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.1914315958802,
-                "content.proton.resource_usage.memory.average": 0.4961770859594,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0015792447621,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006133459521,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2841.266666
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 18343.3,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10323082,
-                "content.proton.documentdb.documents.ready.last": 10323082,
-                "content.proton.documentdb.documents.total.last": 10323082,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66937157326,
-                "content.proton.documentdb.disk_usage.last": 14250411228,
-                "content.proton.transactionlog.disk_usage.last": 3021471440
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002340206429,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0023076890045
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "sparse_abc_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277292,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 409735168,
-                "memory_rss": 198914048,
-                "cpu": 10.8170334788023,
-                "cpu_util": 0.3380322962126
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277292,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 979820544,
-                "memory_rss": 313552896,
-                "cpu": 0.4688497483072,
-                "cpu_util": 0.0146515546346
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0083333333333
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.6666666666667
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 55227164
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277292,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277292,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129855488,
-                "memory_rss": 16822272,
-                "cpu": 0.2679141418898,
-                "cpu_util": 0.0083723169341
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.qrserver",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 29403947008,
-                "memory_rss": 21668212736,
-                "cpu": 61.7415503667456,
-                "cpu_util": 3.8588468979216
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "degraded_queries.rate": 0
-              },
-              "dimensions": {
-                "reason": "timeout",
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "degraded_queries.rate": 1.75
-              },
-              "dimensions": {
-                "reason": "match_phase",
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "failed_queries.rate": 0,
-                "hits_per_query.average": 19.0432481937519,
-                "queries.rate": 163.7833333333333,
-                "query_latency.average": 3.6437818990536,
-                "query_latency.95percentile": 9.6171875,
-                "query_latency.99percentile": 27.4921875,
-                "totalhits_per_query.average": 247.4590414165056
-              },
-              "dimensions": {
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.8096828046745
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "ConcurrentMarkSweep",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 10770160621.333334
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 163.8666666666667
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.4xx.rate": 0
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 14.6666666666667
-              },
-              "dimensions": {
-                "gcName": "ParNew",
-                "serviceId": "qrserver"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 985260032,
-                "memory_rss": 325197824,
-                "cpu": 0.5958970008587,
-                "cpu_util": 0.0372435625537
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0083333333333
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.5
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 65159328
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129875968,
-                "memory_rss": 18456576,
-                "cpu": 0.4303700561757,
-                "cpu_util": 0.026898128511
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277299,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 73003085824,
-                "memory_rss": 67617730560,
-                "cpu": 65.9993933879284,
-                "cpu_util": 2.0624810433728
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.116666,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 9,
-                "content.proton.documentdb.documents.ready.last": 9,
-                "content.proton.documentdb.documents.total.last": 9,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10949856,
-                "content.proton.documentdb.disk_usage.last": 3290619,
-                "content.proton.transactionlog.disk_usage.last": 2440514
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001451384494,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000375890746
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "sparse_def_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.2038824708056,
-                "content.proton.resource_usage.memory.average": 0.4961437008751,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.001749457834,
-                "content.proton.search_protocol.docsum.latency.average": 0.0007628108148,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2371.5
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 15747.05,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10293506,
-                "content.proton.documentdb.documents.ready.last": 10293506,
-                "content.proton.documentdb.documents.total.last": 10293506,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66949272534,
-                "content.proton.documentdb.disk_usage.last": 14616600736,
-                "content.proton.transactionlog.disk_usage.last": 6054632923
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002939150887,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0024796493294
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "sparse_abc_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277299,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 443289600,
-                "memory_rss": 232497152,
-                "cpu": 12.7012017194315,
-                "cpu_util": 0.3969125537322
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277299,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 985714688,
-                "memory_rss": 332480512,
-                "cpu": 0.5856944139395,
-                "cpu_util": 0.0183029504356
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0033333333333
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0.3333333333333
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 40883033.333333336
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277299,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277299,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 18636800,
-                "cpu": 0.3346825222512,
-                "cpu_util": 0.0104588288203
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.qrserver",
-          "timestamp": 1699277297,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 29440122880,
-                "memory_rss": 21881995264,
-                "cpu": 74.3767355913657,
-                "cpu_util": 4.6485459744604
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "degraded_queries.rate": 1.8333333333333
-              },
-              "dimensions": {
-                "chain": "default",
-                "reason": "match_phase",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "failed_queries.rate": 0,
-                "hits_per_query.average": 18.9658650906868,
-                "queries.rate": 163.5833333333333,
-                "query_latency.average": 3.8661718296311,
-                "query_latency.95percentile": 9.3046875,
-                "query_latency.99percentile": 27.3671875,
-                "totalhits_per_query.average": 255.3472590177298
-              },
-              "dimensions": {
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.8096828046745
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "ConcurrentMarkSweep",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 9828423368
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 163.7833333333333
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.4xx.rate": 0
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 15
-              },
-              "dimensions": {
-                "gcName": "ParNew",
-                "serviceId": "qrserver"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277297,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 984727552,
-                "memory_rss": 307425280,
-                "cpu": 0.6937203852626,
-                "cpu_util": 0.0433575240789
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0033388981636
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 35652678.666666664
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277297,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277297,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129961984,
-                "memory_rss": 16678912,
-                "cpu": 0.6111346251123,
-                "cpu_util": 0.0381959140695
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.container",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 29663633408,
-                "memory_rss": 22216187904,
-                "cpu": 4.1818257851378,
-                "cpu_util": 0.2613641115711
-              },
-              "dimensions": {
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "ConcurrentMarkSweep",
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "feed.operations.rate": 0
-              },
-              "dimensions": {
-                "status": "OK",
-                "operation": "PUT",
-                "api": "vespa.http.server",
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.0333333333333
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "feed.operations.rate": 0
-              },
-              "dimensions": {
-                "status": "OK",
-                "operation": "REMOVE",
-                "api": "vespa.http.server",
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "ParNew",
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 13090986996
-              },
-              "dimensions": {
-                "serviceId": "container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 976064512,
-                "memory_rss": 316944384,
-                "cpu": 0.7192740350437,
-                "cpu_util": 0.0449546271902
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0050083472454
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.6666666666667
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 69367185.33333333
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129859584,
-                "memory_rss": 16670720,
-                "cpu": 0.6021829130598,
-                "cpu_util": 0.0376364320662
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.configserver",
-          "timestamp": 1699277286,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
+                "statusCode": "200",
+                "protocol": "http1",
+                "requestType": "monitoring",
                 "serviceId": "configserver"
               }
             },
             {
               "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "configserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "configserver"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 502816737.3333333
-              },
-              "dimensions": {
-                "serviceId": "configserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
+                "jdisc.gc.ms.average": 0,
+                "jdisc.gc.ms.last": 0,
+                "jdisc.gc.ms.max": 0,
+                "jdisc.gc.count.average": 0,
+                "jdisc.gc.count.last": 0,
+                "jdisc.gc.count.max": 0
               },
               "dimensions": {
                 "gcName": "G1YoungGeneration",
@@ -8762,7 +484,197 @@
             },
             {
               "values": {
-                "serverActiveThreads.average": 0
+                "handled.latency.sum": 0,
+                "handled.latency.count": 0,
+                "handled.latency.max": 14,
+                "handled.requests.count": 0
+              },
+              "dimensions": {
+                "handler": "http://*:*/config/v1/*/*",
+                "endpoint": "localhost:19071",
+                "handler-name": "com.yahoo.vespa.config.server.http.HttpGetConfigHandler",
+                "serviceId": "configserver"
+              }
+            },
+            {
+              "values": {
+                "jdisc.gc.ms.average": 0,
+                "jdisc.gc.ms.last": 0,
+                "jdisc.gc.ms.max": 0,
+                "jdisc.gc.count.average": 0,
+                "jdisc.gc.count.last": 0,
+                "jdisc.gc.count.max": 0
+              },
+              "dimensions": {
+                "gcName": "G1OldGeneration",
+                "serviceId": "configserver"
+              }
+            },
+            {
+              "values": {
+                "http.status.4xx.rate": 0.0833333333333
+              },
+              "dimensions": {
+                "httpMethod": "GET",
+                "statusCode": "404",
+                "protocol": "http1",
+                "requestType": "read",
+                "serviceId": "configserver"
+              }
+            },
+            {
+              "values": {
+                "handled.latency.sum": 0,
+                "handled.latency.count": 0,
+                "handled.latency.max": 9,
+                "handled.requests.count": 0
+              },
+              "dimensions": {
+                "handler": "http://*:*/config/v1/",
+                "endpoint": "localhost:19071",
+                "handler-name": "com.yahoo.vespa.config.server.http.HttpListConfigsHandler",
+                "serviceId": "configserver"
+              }
+            },
+            {
+              "values": {
+                "serverActiveThreads.sum": 0,
+                "serverActiveThreads.count": 597,
+                "serverActiveThreads.last": 0,
+                "serverActiveThreads.max": 0,
+                "serverActiveThreads.min": 0,
+                "serverThreadPoolSize.last": 22,
+                "serverThreadPoolSize.max": 22,
+                "jdisc.thread_pool.work_queue.capacity.sum": 525360,
+                "jdisc.thread_pool.work_queue.capacity.count": 597,
+                "jdisc.thread_pool.work_queue.capacity.last": 880,
+                "jdisc.thread_pool.work_queue.capacity.max": 880,
+                "jdisc.thread_pool.work_queue.capacity.min": 880,
+                "jdisc.thread_pool.work_queue.size.sum": 0,
+                "jdisc.thread_pool.work_queue.size.count": 597,
+                "jdisc.thread_pool.work_queue.size.last": 0,
+                "jdisc.thread_pool.work_queue.size.max": 0,
+                "jdisc.thread_pool.work_queue.size.min": 0,
+                "jdisc.thread_pool.max_allowed_size.sum": 13134,
+                "jdisc.thread_pool.max_allowed_size.count": 597,
+                "jdisc.thread_pool.max_allowed_size.last": 22,
+                "jdisc.thread_pool.max_allowed_size.max": 22,
+                "jdisc.thread_pool.max_allowed_size.min": 22,
+                "jdisc.thread_pool.active_threads.sum": 0,
+                "jdisc.thread_pool.active_threads.count": 597,
+                "jdisc.thread_pool.active_threads.last": 0,
+                "jdisc.thread_pool.active_threads.max": 0,
+                "jdisc.thread_pool.active_threads.min": 0,
+                "jdisc.thread_pool.size.sum": 13134,
+                "jdisc.thread_pool.size.count": 597,
+                "jdisc.thread_pool.size.last": 22,
+                "jdisc.thread_pool.size.max": 22,
+                "jdisc.thread_pool.size.min": 22
+              },
+              "dimensions": {
+                "threadpool": "default-handler-common",
+                "serviceId": "configserver"
+              }
+            },
+            {
+              "values": {
+                "handled.latency.sum": 0,
+                "handled.latency.count": 0,
+                "handled.latency.max": 20,
+                "handled.requests.count": 0
+              },
+              "dimensions": {
+                "handler": "http://*:*/application/v2/tenant/*/application/*",
+                "endpoint": "localhost:19071",
+                "handler-name": "com.yahoo.vespa.config.server.http.v2.ApplicationHandler",
+                "serviceId": "configserver"
+              }
+            },
+            {
+              "values": {
+                "handled.latency.sum": 0,
+                "handled.latency.count": 0,
+                "handled.latency.max": 6,
+                "handled.requests.count": 0
+              },
+              "dimensions": {
+                "handler": "http://*:*/application/v2/tenant/*/application/",
+                "endpoint": "localhost:19071",
+                "handler-name": "com.yahoo.vespa.config.server.http.v2.ListApplicationsHandler",
+                "serviceId": "configserver"
+              }
+            },
+            {
+              "values": {
+                "serverBytesSent.sum": 0,
+                "serverBytesSent.count": 7,
+                "jdisc.http.request.uri_length.sum": 221,
+                "jdisc.http.request.uri_length.count": 12,
+                "jdisc.http.request.uri_length.max": 32,
+                "jdisc.http.requests.count": 12,
+                "jdisc.http.requests.rate": 0.2,
+                "jdisc.http.request.content_size.sum": 0,
+                "jdisc.http.request.content_size.count": 7,
+                "jdisc.http.request.content_size.max": 0
+              },
+              "dimensions": {
+                "serverPort": "19071",
+                "serverName": "configserver",
+                "protocol": "HTTP/1.1",
+                "httpMethod": "GET",
+                "serviceId": "configserver"
+              }
+            },
+            {
+              "values": {
+                "mem.native.free.average": 63925541055146.7,
+                "jdisc.http.jetty.threadpool.thread.total.sum": 810,
+                "jdisc.http.jetty.threadpool.thread.total.count": 30,
+                "jdisc.http.jetty.threadpool.thread.total.last": 27,
+                "jdisc.http.jetty.threadpool.thread.total.max": 27,
+                "jdisc.http.jetty.threadpool.thread.total.min": 27,
+                "jdisc.open_file_descriptors.max": 446,
+                "mem.native.used.average": 185040828192085,
+                "jdisc.tls.capability_checks.failed.rate": 0,
+                "jdisc.deactivated_containers.total.sum": 0,
+                "jdisc.deactivated_containers.total.last": 0,
+                "jdisc.memory_mappings.max": 752,
+                "jdisc.http.jetty.threadpool.thread.max.sum": 810,
+                "jdisc.http.jetty.threadpool.thread.max.count": 30,
+                "jdisc.http.jetty.threadpool.thread.max.last": 27,
+                "jdisc.http.jetty.threadpool.thread.max.max": 27,
+                "jdisc.http.jetty.threadpool.thread.max.min": 27,
+                "jdisc.http.jetty.threadpool.thread.reserved.sum": -30,
+                "jdisc.http.jetty.threadpool.thread.reserved.count": 30,
+                "jdisc.http.jetty.threadpool.thread.reserved.last": -1,
+                "jdisc.http.jetty.threadpool.thread.reserved.max": -1,
+                "jdisc.http.jetty.threadpool.thread.reserved.min": -1,
+                "mem.heap.used.average": 1243012906.66667,
+                "mem.heap.used.max": 1263403336,
+                "mem.native.total.average": 248966369247232,
+                "jdisc.tls.capability_checks.succeeded.rate": 0,
+                "mem.direct.count.max": 121,
+                "jdisc.http.jetty.threadpool.queue.size.sum": 0,
+                "jdisc.http.jetty.threadpool.queue.size.count": 30,
+                "jdisc.http.jetty.threadpool.queue.size.last": 0,
+                "jdisc.http.jetty.threadpool.queue.size.max": 0,
+                "jdisc.http.jetty.threadpool.queue.size.min": 0,
+                "mem.direct.free.average": -2,
+                "mem.heap.total.average": 1698693120,
+                "mem.direct.used.average": 102688385.666667,
+                "mem.direct.used.max": 102688697,
+                "jdisc.http.jetty.threadpool.thread.busy.sum": 60,
+                "jdisc.http.jetty.threadpool.thread.busy.count": 30,
+                "jdisc.http.jetty.threadpool.thread.busy.last": 2,
+                "jdisc.http.jetty.threadpool.thread.busy.max": 2,
+                "jdisc.http.jetty.threadpool.thread.busy.min": 2,
+                "mem.direct.total.average": 102688383.666667,
+                "jdisc.http.jetty.threadpool.thread.min.sum": 810,
+                "jdisc.http.jetty.threadpool.thread.min.count": 30,
+                "jdisc.http.jetty.threadpool.thread.min.last": 27,
+                "jdisc.http.jetty.threadpool.thread.min.max": 27,
+                "jdisc.http.jetty.threadpool.thread.min.min": 27,
+                "mem.heap.free.average": 455680213.333333
               },
               "dimensions": {
                 "serviceId": "configserver"
@@ -8772,7 +684,7 @@
         },
         {
           "name": "vespa.logserver",
-          "timestamp": 1699277286,
+          "timestamp": 1760044773,
           "status": {
             "code": "up",
             "description": "Data collected successfully"
@@ -8780,10 +692,10 @@
           "metrics": [
             {
               "values": {
-                "memory_virt": 893038592,
-                "memory_rss": 150343680,
-                "cpu": 1.0570213468764,
-                "cpu_util": 0.1321276683596
+                "memory_virt": 898256896,
+                "memory_rss": 71905280,
+                "cpu": 0.1519267068735,
+                "cpu_util": 0.0138115188067
               },
               "dimensions": {
                 "serviceId": "logserver"
@@ -8798,8 +710,8 @@
           ]
         },
         {
-          "name": "vespa.slobrok",
-          "timestamp": 1699277286,
+          "name": "vespa.logserver-container",
+          "timestamp": 1760044773,
           "status": {
             "code": "up",
             "description": "Data collected successfully"
@@ -8807,17 +719,261 @@
           "metrics": [
             {
               "values": {
-                "memory_virt": 122761216,
-                "memory_rss": 18513920,
-                "cpu": 2.064494818118,
-                "cpu_util": 0.2580618522648
+                "memory_virt": 747057152,
+                "memory_rss": 117882880,
+                "cpu": 1.9750471893559,
+                "cpu_util": 0.1795497444869
+              },
+              "dimensions": {
+                "serviceId": "logserver-container"
+              }
+            },
+            {
+              "values": {
+                "jdisc.gc.ms.average": 7.5,
+                "jdisc.gc.ms.last": 9,
+                "jdisc.gc.ms.max": 9,
+                "jdisc.gc.count.average": 0.8333333333333,
+                "jdisc.gc.count.last": 1,
+                "jdisc.gc.count.max": 1
+              },
+              "dimensions": {
+                "gcName": "Copy",
+                "serviceId": "logserver-container"
+              }
+            },
+            {
+              "values": {
+                "serverNumConnections.average": 32,
+                "serverNumConnections.last": 32,
+                "serverNumConnections.max": 32,
+                "serverNumOpenConnections.average": 1,
+                "serverNumOpenConnections.last": 1,
+                "serverNumOpenConnections.max": 1
+              },
+              "dimensions": {
+                "serverName": "SearchServer",
+                "serverPort": "19103",
+                "serviceId": "logserver-container"
+              }
+            },
+            {
+              "values": {
+                "serverBytesSent.sum": 0,
+                "serverBytesSent.count": 4,
+                "jdisc.http.request.uri_length.sum": 68,
+                "jdisc.http.request.uri_length.count": 4,
+                "jdisc.http.request.uri_length.max": 17,
+                "jdisc.http.requests.count": 4,
+                "jdisc.http.requests.rate": 0.0666666666667,
+                "jdisc.http.request.content_size.sum": 0,
+                "jdisc.http.request.content_size.count": 4,
+                "jdisc.http.request.content_size.max": 0
+              },
+              "dimensions": {
+                "serverPort": "19103",
+                "serverName": "SearchServer",
+                "protocol": "HTTP/1.1",
+                "httpMethod": "GET",
+                "serviceId": "logserver-container"
+              }
+            },
+            {
+              "values": {
+                "http.status.2xx.rate": 0.0666666666667
+              },
+              "dimensions": {
+                "httpMethod": "GET",
+                "statusCode": "200",
+                "protocol": "http1",
+                "requestType": "monitoring",
+                "serviceId": "logserver-container"
+              }
+            },
+            {
+              "values": {
+                "jdisc.jvm.last": 17
+              },
+              "dimensions": {
+                "vendor": "Red Hat, Inc.",
+                "serviceId": "logserver-container"
+              }
+            },
+            {
+              "values": {
+                "serverActiveThreads.sum": 0,
+                "serverActiveThreads.count": 597,
+                "serverActiveThreads.last": 0,
+                "serverActiveThreads.max": 0,
+                "serverActiveThreads.min": 0,
+                "serverThreadPoolSize.last": 8,
+                "serverThreadPoolSize.max": 8,
+                "jdisc.thread_pool.work_queue.capacity.sum": 388050,
+                "jdisc.thread_pool.work_queue.capacity.count": 597,
+                "jdisc.thread_pool.work_queue.capacity.last": 650,
+                "jdisc.thread_pool.work_queue.capacity.max": 650,
+                "jdisc.thread_pool.work_queue.capacity.min": 650,
+                "jdisc.thread_pool.work_queue.size.sum": 0,
+                "jdisc.thread_pool.work_queue.size.count": 597,
+                "jdisc.thread_pool.work_queue.size.last": 0,
+                "jdisc.thread_pool.work_queue.size.max": 0,
+                "jdisc.thread_pool.work_queue.size.min": 0,
+                "jdisc.thread_pool.max_allowed_size.sum": 4776,
+                "jdisc.thread_pool.max_allowed_size.count": 597,
+                "jdisc.thread_pool.max_allowed_size.last": 8,
+                "jdisc.thread_pool.max_allowed_size.max": 8,
+                "jdisc.thread_pool.max_allowed_size.min": 8,
+                "jdisc.thread_pool.active_threads.sum": 0,
+                "jdisc.thread_pool.active_threads.count": 597,
+                "jdisc.thread_pool.active_threads.last": 0,
+                "jdisc.thread_pool.active_threads.max": 0,
+                "jdisc.thread_pool.active_threads.min": 0,
+                "jdisc.thread_pool.size.sum": 4776,
+                "jdisc.thread_pool.size.count": 597,
+                "jdisc.thread_pool.size.last": 8,
+                "jdisc.thread_pool.size.max": 8,
+                "jdisc.thread_pool.size.min": 8
+              },
+              "dimensions": {
+                "threadpool": "default-handler-common",
+                "serviceId": "logserver-container"
+              }
+            },
+            {
+              "values": {
+                "serverActiveThreads.sum": 0,
+                "serverActiveThreads.count": 597,
+                "serverActiveThreads.last": 0,
+                "serverActiveThreads.max": 0,
+                "serverActiveThreads.min": 0,
+                "serverThreadPoolSize.last": 1,
+                "serverThreadPoolSize.max": 1,
+                "jdisc.thread_pool.work_queue.capacity.sum": 29850,
+                "jdisc.thread_pool.work_queue.capacity.count": 597,
+                "jdisc.thread_pool.work_queue.capacity.last": 50,
+                "jdisc.thread_pool.work_queue.capacity.max": 50,
+                "jdisc.thread_pool.work_queue.capacity.min": 50,
+                "jdisc.thread_pool.work_queue.size.sum": 0,
+                "jdisc.thread_pool.work_queue.size.count": 597,
+                "jdisc.thread_pool.work_queue.size.last": 0,
+                "jdisc.thread_pool.work_queue.size.max": 0,
+                "jdisc.thread_pool.work_queue.size.min": 0,
+                "jdisc.thread_pool.max_allowed_size.sum": 597,
+                "jdisc.thread_pool.max_allowed_size.count": 597,
+                "jdisc.thread_pool.max_allowed_size.last": 1,
+                "jdisc.thread_pool.max_allowed_size.max": 1,
+                "jdisc.thread_pool.max_allowed_size.min": 1,
+                "jdisc.thread_pool.active_threads.sum": 0,
+                "jdisc.thread_pool.active_threads.count": 597,
+                "jdisc.thread_pool.active_threads.last": 0,
+                "jdisc.thread_pool.active_threads.max": 0,
+                "jdisc.thread_pool.active_threads.min": 0,
+                "jdisc.thread_pool.size.sum": 597,
+                "jdisc.thread_pool.size.count": 597,
+                "jdisc.thread_pool.size.last": 1,
+                "jdisc.thread_pool.size.max": 1,
+                "jdisc.thread_pool.size.min": 1
+              },
+              "dimensions": {
+                "threadpool": "default-pool",
+                "serviceId": "logserver-container"
+              }
+            },
+            {
+              "values": {
+                "mem.direct.free.average": 0,
+                "mem.native.free.average": 20360102324906.7,
+                "jdisc.http.jetty.threadpool.thread.total.sum": 120,
+                "jdisc.http.jetty.threadpool.thread.total.count": 30,
+                "jdisc.http.jetty.threadpool.thread.total.last": 4,
+                "jdisc.http.jetty.threadpool.thread.total.max": 4,
+                "jdisc.http.jetty.threadpool.thread.total.min": 4,
+                "jdisc.open_file_descriptors.max": 92,
+                "mem.heap.total.average": 36360192,
+                "mem.direct.used.average": 888772,
+                "mem.direct.used.max": 888772,
+                "mem.native.used.average": 19295330719061.3,
+                "jdisc.tls.capability_checks.failed.rate": 0,
+                "jdisc.http.jetty.threadpool.thread.busy.sum": 60,
+                "jdisc.http.jetty.threadpool.thread.busy.count": 30,
+                "jdisc.http.jetty.threadpool.thread.busy.last": 2,
+                "jdisc.http.jetty.threadpool.thread.busy.max": 2,
+                "jdisc.http.jetty.threadpool.thread.busy.min": 2,
+                "jdisc.deactivated_containers.total.sum": 0,
+                "jdisc.deactivated_containers.total.last": 0,
+                "mem.direct.total.average": 888772,
+                "jdisc.memory_mappings.max": 293,
+                "jdisc.http.jetty.threadpool.thread.max.sum": 120,
+                "jdisc.http.jetty.threadpool.thread.max.count": 30,
+                "jdisc.http.jetty.threadpool.thread.max.last": 4,
+                "jdisc.http.jetty.threadpool.thread.max.max": 4,
+                "jdisc.http.jetty.threadpool.thread.max.min": 4,
+                "jdisc.http.jetty.threadpool.thread.reserved.sum": -30,
+                "jdisc.http.jetty.threadpool.thread.reserved.count": 30,
+                "jdisc.http.jetty.threadpool.thread.reserved.last": -1,
+                "jdisc.http.jetty.threadpool.thread.reserved.max": -1,
+                "jdisc.http.jetty.threadpool.thread.reserved.min": -1,
+                "mem.heap.used.average": 22106996,
+                "mem.heap.used.max": 24249304,
+                "mem.native.total.average": 39655433043968,
+                "jdisc.tls.capability_checks.succeeded.rate": 0,
+                "mem.direct.count.max": 12,
+                "jdisc.http.jetty.threadpool.thread.min.sum": 120,
+                "jdisc.http.jetty.threadpool.thread.min.count": 30,
+                "jdisc.http.jetty.threadpool.thread.min.last": 4,
+                "jdisc.http.jetty.threadpool.thread.min.max": 4,
+                "jdisc.http.jetty.threadpool.thread.min.min": 4,
+                "mem.heap.free.average": 14253196,
+                "jdisc.http.jetty.threadpool.queue.size.sum": 0,
+                "jdisc.http.jetty.threadpool.queue.size.count": 30,
+                "jdisc.http.jetty.threadpool.queue.size.last": 0,
+                "jdisc.http.jetty.threadpool.queue.size.max": 0,
+                "jdisc.http.jetty.threadpool.queue.size.min": 0
+              },
+              "dimensions": {
+                "serviceId": "logserver-container"
+              }
+            },
+            {
+              "values": {
+                "jdisc.gc.ms.average": 0,
+                "jdisc.gc.ms.last": 0,
+                "jdisc.gc.ms.max": 0,
+                "jdisc.gc.count.average": 0,
+                "jdisc.gc.count.last": 0,
+                "jdisc.gc.count.max": 0
+              },
+              "dimensions": {
+                "gcName": "MarkSweepCompact",
+                "serviceId": "logserver-container"
+              }
+            }
+          ]
+        },
+        {
+          "name": "vespa.slobrok",
+          "timestamp": 1760044773,
+          "status": {
+            "code": "up",
+            "description": "Data collected successfully"
+          },
+          "metrics": [
+            {
+              "values": {
+                "memory_virt": 117399552,
+                "memory_rss": 2838528,
+                "cpu": 0.590826082286,
+                "cpu_util": 0.053711462026
               },
               "dimensions": {
                 "serviceId": "slobrok"
               }
             },
             {
-              "values": {},
+              "values": {
+                "slobrok.heartbeats.failed.count": 0,
+                "slobrok.missing.consensus.count": 0
+              },
               "dimensions": {
                 "serviceId": "slobrok"
               }
@@ -8826,7 +982,7 @@
         },
         {
           "name": "vespa.container-clustercontroller",
-          "timestamp": 1699277286,
+          "timestamp": 1760044773,
           "status": {
             "code": "up",
             "description": "Data collected successfully"
@@ -8834,10 +990,10 @@
           "metrics": [
             {
               "values": {
-                "memory_virt": 854663168,
-                "memory_rss": 283947008,
-                "cpu": 3.0719682893596,
-                "cpu_util": 0.3839960361699
+                "memory_virt": 766005248,
+                "memory_rss": 191528960,
+                "cpu": 2.3970658195602,
+                "cpu_util": 0.2179150745055
               },
               "dimensions": {
                 "serviceId": "container-clustercontroller"
@@ -8845,7 +1001,227 @@
             },
             {
               "values": {
-                "serverActiveThreads.average": 0
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 600,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "workId": "processNextQueuedRemoteTask",
+                "cluster": "web",
+                "didWork": "false",
+                "controller-index": "0",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 600,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "workId": "watchTimers",
+                "cluster": "web",
+                "didWork": "false",
+                "controller-index": "0",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 598,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "didWork": "false",
+                "workId": "stateGatherer-processResponses",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 600,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "workId": "handleLeadershipEdgeTransitions",
+                "cluster": "web",
+                "didWork": "false",
+                "controller-index": "0",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0.008,
+                "cluster-controller.work-ms.count": 600,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "didWork": "false",
+                "workId": "broadcastClusterStateToEligibleNodes",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "serverBytesSent.sum": 0,
+                "serverBytesSent.count": 2,
+                "jdisc.http.request.uri_length.sum": 34,
+                "jdisc.http.request.uri_length.count": 2,
+                "jdisc.http.request.uri_length.max": 17,
+                "jdisc.http.requests.count": 2,
+                "jdisc.http.requests.rate": 0.0333333333333,
+                "jdisc.http.request.content_size.sum": 0,
+                "jdisc.http.request.content_size.count": 2,
+                "jdisc.http.request.content_size.max": 0
+              },
+              "dimensions": {
+                "serverPort": "19050",
+                "serverName": "SearchServer",
+                "protocol": "HTTP/1.1",
+                "httpMethod": "GET",
+                "serviceId": "container-clustercontroller"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 0,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "workId": "updateMasterElectionState",
+                "didWork": "true",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 0,
+                "cluster-controller.work-ms.last": 0.011
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "didWork": "true",
+                "workId": "recomputeClusterStateIfRequired",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.retired.count.last": 0,
+                "cluster-controller.retired.count.max": 0,
+                "cluster-controller.maintenance.count.last": 0,
+                "cluster-controller.maintenance.count.max": 0,
+                "cluster-controller.stopping.count.last": 0,
+                "cluster-controller.nodes-not-converged.max": 0,
+                "cluster-controller.down.count.last": 0,
+                "cluster-controller.down.count.max": 0,
+                "cluster-controller.initializing.count.last": 0,
+                "cluster-controller.initializing.count.max": 0,
+                "cluster-controller.up.count.last": 1,
+                "cluster-controller.up.count.max": 1
+              },
+              "dimensions": {
+                "cluster": "web",
+                "node-type": "storage",
+                "controller-index": "0",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "jdisc.jvm.last": 17
+              },
+              "dimensions": {
+                "vendor": "Red Hat, Inc.",
+                "serviceId": "container-clustercontroller"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 600,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "workId": "processAnyPendingStatusPageRequest",
+                "cluster": "web",
+                "didWork": "false",
+                "controller-index": "0",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "mem.native.free.average": 19173363154944,
+                "jdisc.http.jetty.threadpool.thread.total.sum": 120,
+                "jdisc.http.jetty.threadpool.thread.total.count": 30,
+                "jdisc.http.jetty.threadpool.thread.total.last": 4,
+                "jdisc.http.jetty.threadpool.thread.total.max": 4,
+                "jdisc.http.jetty.threadpool.thread.total.min": 4,
+                "jdisc.open_file_descriptors.max": 176,
+                "mem.native.used.average": 28024032460800,
+                "jdisc.tls.capability_checks.failed.rate": 0,
+                "jdisc.deactivated_containers.total.sum": 0,
+                "jdisc.deactivated_containers.total.last": 0,
+                "jdisc.memory_mappings.max": 350,
+                "jdisc.http.jetty.threadpool.thread.max.sum": 120,
+                "jdisc.http.jetty.threadpool.thread.max.count": 30,
+                "jdisc.http.jetty.threadpool.thread.max.last": 4,
+                "jdisc.http.jetty.threadpool.thread.max.max": 4,
+                "jdisc.http.jetty.threadpool.thread.max.min": 4,
+                "jdisc.http.jetty.threadpool.thread.reserved.sum": -30,
+                "jdisc.http.jetty.threadpool.thread.reserved.count": 30,
+                "jdisc.http.jetty.threadpool.thread.reserved.last": -1,
+                "jdisc.http.jetty.threadpool.thread.reserved.max": -1,
+                "jdisc.http.jetty.threadpool.thread.reserved.min": -1,
+                "mem.heap.used.average": 32577521.3333333,
+                "mem.heap.used.max": 39564368,
+                "mem.native.total.average": 47197395615744,
+                "jdisc.tls.capability_checks.succeeded.rate": 0,
+                "mem.direct.count.max": 25,
+                "jdisc.http.jetty.threadpool.queue.size.sum": 0,
+                "jdisc.http.jetty.threadpool.queue.size.count": 30,
+                "jdisc.http.jetty.threadpool.queue.size.last": 0,
+                "jdisc.http.jetty.threadpool.queue.size.max": 0,
+                "jdisc.http.jetty.threadpool.queue.size.min": 0,
+                "mem.direct.free.average": -1,
+                "mem.heap.total.average": 55848960,
+                "mem.direct.used.average": 1371462,
+                "mem.direct.used.max": 1371462,
+                "jdisc.http.jetty.threadpool.thread.busy.sum": 60,
+                "jdisc.http.jetty.threadpool.thread.busy.count": 30,
+                "jdisc.http.jetty.threadpool.thread.busy.last": 2,
+                "jdisc.http.jetty.threadpool.thread.busy.max": 2,
+                "jdisc.http.jetty.threadpool.thread.busy.min": 2,
+                "mem.direct.total.average": 1371461,
+                "jdisc.http.jetty.threadpool.thread.min.sum": 120,
+                "jdisc.http.jetty.threadpool.thread.min.count": 30,
+                "jdisc.http.jetty.threadpool.thread.min.last": 4,
+                "jdisc.http.jetty.threadpool.thread.min.max": 4,
+                "jdisc.http.jetty.threadpool.thread.min.min": 4,
+                "mem.heap.free.average": 23271438.6666667
               },
               "dimensions": {
                 "serviceId": "container-clustercontroller"
@@ -8853,177 +1229,458 @@
             },
             {
               "values": {
-                "jdisc.gc.ms.average": 6.6666666666667
+                "jdisc.http.request.requests_per_connection.average": 2,
+                "jdisc.http.request.requests_per_connection.sum": 0,
+                "jdisc.http.request.requests_per_connection.count": 0,
+                "jdisc.http.request.requests_per_connection.max": 2,
+                "jdisc.http.request.requests_per_connection.min": 2,
+                "serverNumConnections.average": 34,
+                "serverNumConnections.last": 34,
+                "serverNumConnections.max": 34,
+                "serverNumOpenConnections.average": 1,
+                "serverNumOpenConnections.last": 1,
+                "serverNumOpenConnections.max": 1
               },
               "dimensions": {
-                "gcName": "G1YoungGeneration",
+                "serverName": "SearchServer",
+                "serverPort": "19050",
                 "serviceId": "container-clustercontroller"
               }
             },
             {
               "values": {
-                "jdisc.gc.ms.average": 0
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 0,
+                "cluster-controller.work-ms.last": 0.011
               },
               "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "container-clustercontroller"
+                "workId": "handleLeadershipEdgeTransitions",
+                "cluster": "web",
+                "didWork": "true",
+                "controller-index": "0",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
               }
             },
             {
               "values": {
-                "mem.heap.free.average": 34906717.333333336
+                "cluster-controller.resource_usage.nodes_above_limit.last": 0,
+                "cluster-controller.resource_usage.nodes_above_limit.max": 0,
+                "cluster-controller.cluster-buckets-out-of-sync-ratio.max": 0,
+                "cluster-controller.cluster-state-change.count": 2,
+                "cluster-controller.idle-tick-time-ms.sum": 95,
+                "cluster-controller.idle-tick-time-ms.count": 596,
+                "cluster-controller.idle-tick-time-ms.last": 0,
+                "cluster-controller.idle-tick-time-ms.max": 9,
+                "cluster-controller.node-event.count": 0,
+                "cluster-controller.busy-tick-time-ms.sum": 3,
+                "cluster-controller.busy-tick-time-ms.count": 4,
+                "cluster-controller.busy-tick-time-ms.last": 1,
+                "cluster-controller.busy-tick-time-ms.max": 2,
+                "cluster-controller.resource_usage.disk_limit.last": 0.75,
+                "cluster-controller.resource_usage.disk_limit.max": 0.75,
+                "cluster-controller.resource_usage.max_memory_utilization.last": 0.0152081923888,
+                "cluster-controller.resource_usage.max_memory_utilization.max": 0.0152081923888,
+                "cluster-controller.resource_usage.max_disk_utilization.last": 0.1860370808773,
+                "cluster-controller.resource_usage.max_disk_utilization.max": 0.186037174886,
+                "cluster-controller.resource_usage.memory_limit.last": 0.8,
+                "cluster-controller.resource_usage.memory_limit.max": 0.8,
+                "cluster-controller.is-master.last": 1,
+                "cluster-controller.is-master.max": 1,
+                "cluster-controller.remote-task-queue.size.last": 0
               },
               "dimensions": {
-                "serviceId": "container-clustercontroller"
+                "cluster": "web",
+                "controller-index": "0",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
               }
             },
             {
               "values": {
-                "http.status.2xx.rate": 0.1166666666667
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 600,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "workId": "systemStateBroadcaster-processResponses",
+                "didWork": "false",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 0,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "workId": "systemStateBroadcaster-processResponses",
+                "didWork": "true",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 600,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "workId": "updateCluster",
+                "cluster": "web",
+                "didWork": "false",
+                "controller-index": "0",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "http.status.2xx.rate": 0.0333333333333
               },
               "dimensions": {
                 "httpMethod": "GET",
+                "statusCode": "200",
+                "protocol": "http1",
+                "requestType": "monitoring",
                 "serviceId": "container-clustercontroller"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0.001,
+                "cluster-controller.work-ms.count": 2,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "didWork": "true",
+                "workId": "stateGatherer-processResponses",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.retired.count.last": 0,
+                "cluster-controller.retired.count.max": 0,
+                "cluster-controller.maintenance.count.last": 0,
+                "cluster-controller.maintenance.count.max": 0,
+                "cluster-controller.stopping.count.last": 0,
+                "cluster-controller.nodes-not-converged.max": 0,
+                "cluster-controller.down.count.last": 0,
+                "cluster-controller.down.count.max": 0,
+                "cluster-controller.initializing.count.last": 0,
+                "cluster-controller.initializing.count.max": 0,
+                "cluster-controller.up.count.last": 1,
+                "cluster-controller.up.count.max": 1
+              },
+              "dimensions": {
+                "cluster": "web",
+                "node-type": "distributor",
+                "controller-index": "0",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 598,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "workId": "sendMessages",
+                "didWork": "false",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "http.status.4xx.rate": 0
+              },
+              "dimensions": {
+                "httpMethod": "GET",
+                "statusCode": "404",
+                "protocol": "http1",
+                "requestType": "read",
+                "serviceId": "container-clustercontroller"
+              }
+            },
+            {
+              "values": {
+                "jdisc.gc.ms.average": 0,
+                "jdisc.gc.ms.last": 0,
+                "jdisc.gc.ms.max": 0,
+                "jdisc.gc.count.average": 0,
+                "jdisc.gc.count.last": 0,
+                "jdisc.gc.count.max": 0
+              },
+              "dimensions": {
+                "gcName": "MarkSweepCompact",
+                "serviceId": "container-clustercontroller"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 2,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "workId": "maybePublishOldMetrics",
+                "didWork": "true",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "handled.latency.sum": 0,
+                "handled.latency.count": 0,
+                "handled.latency.max": 55,
+                "jdisc.http.handler.unhandled_exceptions.rate": 0,
+                "handled.requests.count": 0
+              },
+              "dimensions": {
+                "handler": "http://*:*/clustercontroller-status/*",
+                "endpoint": "localhost:19050",
+                "handler-name": "com.yahoo.vespa.clustercontroller.apps.clustercontroller.StatusHandler",
+                "serviceId": "container-clustercontroller"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 600,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "workId": "doNextZooKeeperTask",
+                "cluster": "web",
+                "didWork": "false",
+                "controller-index": "0",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "jdisc.gc.ms.average": 14.3333333333333,
+                "jdisc.gc.ms.last": 14,
+                "jdisc.gc.ms.max": 22,
+                "jdisc.gc.count.average": 1.1666666666667,
+                "jdisc.gc.count.last": 1,
+                "jdisc.gc.count.max": 2
+              },
+              "dimensions": {
+                "gcName": "Copy",
+                "serviceId": "container-clustercontroller"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 600,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "workId": "updateMasterElectionState",
+                "didWork": "false",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 0,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "workId": "doNextZooKeeperTask",
+                "cluster": "web",
+                "didWork": "true",
+                "controller-index": "0",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 598,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "didWork": "false",
+                "workId": "maybePublishOldMetrics",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "serverActiveThreads.sum": 0,
+                "serverActiveThreads.count": 597,
+                "serverActiveThreads.last": 0,
+                "serverActiveThreads.max": 0,
+                "serverActiveThreads.min": 0,
+                "serverThreadPoolSize.last": 1,
+                "serverThreadPoolSize.max": 1,
+                "jdisc.thread_pool.work_queue.capacity.sum": 29850,
+                "jdisc.thread_pool.work_queue.capacity.count": 597,
+                "jdisc.thread_pool.work_queue.capacity.last": 50,
+                "jdisc.thread_pool.work_queue.capacity.max": 50,
+                "jdisc.thread_pool.work_queue.capacity.min": 50,
+                "jdisc.thread_pool.work_queue.size.sum": 0,
+                "jdisc.thread_pool.work_queue.size.count": 597,
+                "jdisc.thread_pool.work_queue.size.last": 0,
+                "jdisc.thread_pool.work_queue.size.max": 0,
+                "jdisc.thread_pool.work_queue.size.min": 0,
+                "jdisc.thread_pool.max_allowed_size.sum": 597,
+                "jdisc.thread_pool.max_allowed_size.count": 597,
+                "jdisc.thread_pool.max_allowed_size.last": 1,
+                "jdisc.thread_pool.max_allowed_size.max": 1,
+                "jdisc.thread_pool.max_allowed_size.min": 1,
+                "jdisc.thread_pool.active_threads.sum": 0,
+                "jdisc.thread_pool.active_threads.count": 597,
+                "jdisc.thread_pool.active_threads.last": 0,
+                "jdisc.thread_pool.active_threads.max": 0,
+                "jdisc.thread_pool.active_threads.min": 0,
+                "jdisc.thread_pool.size.sum": 597,
+                "jdisc.thread_pool.size.count": 597,
+                "jdisc.thread_pool.size.last": 1,
+                "jdisc.thread_pool.size.max": 1,
+                "jdisc.thread_pool.size.min": 1
+              },
+              "dimensions": {
+                "threadpool": "default-pool",
+                "serviceId": "container-clustercontroller"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 600,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "didWork": "false",
+                "workId": "recomputeClusterStateIfRequired",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 0,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "didWork": "true",
+                "workId": "broadcastClusterStateToEligibleNodes",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "serverActiveThreads.sum": 0,
+                "serverActiveThreads.count": 597,
+                "serverActiveThreads.last": 0,
+                "serverActiveThreads.max": 0,
+                "serverActiveThreads.min": 0,
+                "serverThreadPoolSize.last": 8,
+                "serverThreadPoolSize.max": 8,
+                "jdisc.thread_pool.work_queue.capacity.sum": 388050,
+                "jdisc.thread_pool.work_queue.capacity.count": 597,
+                "jdisc.thread_pool.work_queue.capacity.last": 650,
+                "jdisc.thread_pool.work_queue.capacity.max": 650,
+                "jdisc.thread_pool.work_queue.capacity.min": 650,
+                "jdisc.thread_pool.work_queue.size.sum": 0,
+                "jdisc.thread_pool.work_queue.size.count": 597,
+                "jdisc.thread_pool.work_queue.size.last": 0,
+                "jdisc.thread_pool.work_queue.size.max": 0,
+                "jdisc.thread_pool.work_queue.size.min": 0,
+                "jdisc.thread_pool.max_allowed_size.sum": 4776,
+                "jdisc.thread_pool.max_allowed_size.count": 597,
+                "jdisc.thread_pool.max_allowed_size.last": 8,
+                "jdisc.thread_pool.max_allowed_size.max": 8,
+                "jdisc.thread_pool.max_allowed_size.min": 8,
+                "jdisc.thread_pool.active_threads.sum": 0,
+                "jdisc.thread_pool.active_threads.count": 597,
+                "jdisc.thread_pool.active_threads.last": 0,
+                "jdisc.thread_pool.active_threads.max": 0,
+                "jdisc.thread_pool.active_threads.min": 0,
+                "jdisc.thread_pool.size.sum": 4776,
+                "jdisc.thread_pool.size.count": 597,
+                "jdisc.thread_pool.size.last": 8,
+                "jdisc.thread_pool.size.max": 8,
+                "jdisc.thread_pool.size.min": 8
+              },
+              "dimensions": {
+                "threadpool": "default-handler-common",
+                "serviceId": "container-clustercontroller"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 2,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "workId": "sendMessages",
+                "didWork": "true",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
+              }
+            },
+            {
+              "values": {
+                "cluster-controller.work-ms.sum": 0,
+                "cluster-controller.work-ms.count": 600,
+                "cluster-controller.work-ms.last": 0
+              },
+              "dimensions": {
+                "controller-index": "0",
+                "cluster": "web",
+                "workId": "completeSatisfiedVersionDependentTasks",
+                "didWork": "false",
+                "serviceId": "container-clustercontroller",
+                "clusterId": "web"
               }
             }
           ]
         },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277286,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 998735872,
-                "memory_rss": 304840704,
-                "cpu": 1.0239894297865,
-                "cpu_util": 0.1279986787233
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0083333333333
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 5.1666666666667
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 42412877.333333336
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277286,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277286,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129867776,
-                "memory_rss": 16510976,
-                "cpu": 0.6110904661629,
-                "cpu_util": 0.0763863082704
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
         {
           "name": "vespa.searchnode",
-          "timestamp": 1699277293,
+          "timestamp": 1760044773,
           "status": {
             "code": "up",
             "description": "Data collected successfully"
@@ -9031,10 +1688,10 @@
           "metrics": [
             {
               "values": {
-                "memory_virt": 73042427904,
-                "memory_rss": 68444844032,
-                "cpu": 58.8302231502023,
-                "cpu_util": 1.8384444734438
+                "memory_virt": 2432073728,
+                "memory_rss": 99610624,
+                "cpu": 2.8866074305971,
+                "cpu_util": 0.262418857327
               },
               "dimensions": {
                 "serviceId": "searchnode"
@@ -9042,76 +1699,1599 @@
             },
             {
               "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 233764,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 103604,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 128,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 12288
               },
               "dimensions": {
-                "rankProfile": "default",
-                "documenttype": "def",
+                "field": "content_tiny_embedding",
+                "documenttype": "web",
                 "serviceId": "searchnode"
               }
             },
             {
               "values": {
-                "content.proton.transactionlog.disk_usage.last": 2256656,
-                "content.proton.documentdb.matching.docs_matched.rate": 0.083333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 9,
-                "content.proton.documentdb.documents.ready.last": 9,
-                "content.proton.documentdb.documents.total.last": 9,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10947296,
-                "content.proton.documentdb.disk_usage.last": 3095093
+                "content.proton.documentdb.ready.index.disk_usage.average": 126976
               },
               "dimensions": {
-                "documenttype": "abc",
+                "field": "og_article_section",
+                "documenttype": "web",
                 "serviceId": "searchnode"
               }
             },
             {
               "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001287727094,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.000032656159
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
               },
               "dimensions": {
-                "rankProfile": "sparse_def_linear",
-                "documenttype": "abc",
+                "field": "domain_trust",
+                "documenttype": "web",
                 "serviceId": "searchnode"
               }
             },
             {
               "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335532,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102584,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 804,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
               },
               "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "abc",
+                "field": "ctr_clicked_7d_windowed",
+                "documenttype": "web",
                 "serviceId": "searchnode"
               }
             },
             {
               "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 426924,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 322852,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 484,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 32768
               },
               "dimensions": {
-                "rankProfile": "unranked",
-                "documenttype": "def",
+                "field": "alternate_urls.url",
+                "documenttype": "web",
                 "serviceId": "searchnode"
               }
             },
             {
               "values": {
-                "content.proton.resource_usage.disk.average": 0.195283744493,
-                "content.proton.resource_usage.memory.average": 0.5000422861732,
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 160036,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 25028,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 16,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "lang_tensor",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335756,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102736,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 600,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "page_rank",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "seen_ctr",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 408088,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 306896,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 264,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 24576
+              },
+              "dimensions": {
+                "field": "og_images.type",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "linked_loc_entities",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "katz_score",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 425020,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 284780,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 160,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "e5_binary_embedding",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335756,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 103560,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 1064,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "domain_rank",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 135168
+              },
+              "dimensions": {
+                "field": "url.path",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335756,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102728,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 600,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "host_katz",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "title_stem",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 16,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "homepage",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 295072,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 254140,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 88,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "og_images.width",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "host_mean_content_length",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 1024,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 512,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "og_article_expiration_time",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335564,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102608,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 804,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "ctr_clicked_1m_windowed",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 406680,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 306648,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 208,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 20480
+              },
+              "dimensions": {
+                "field": "og_article_tag",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 135168
+              },
+              "dimensions": {
+                "field": "title_tag",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 135168
+              },
+              "dimensions": {
+                "field": "og_title",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335628,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 103228,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 1100,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "jsonld_entities_count",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335628,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102724,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 824,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "indegree_count",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335564,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102628,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 804,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "ctr_clicked_3m_windowed",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 294260,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 253944,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 32,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "sitelinks.total_clicks",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 336012,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102764,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 604,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "quality_signal_phishing_score",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 410908,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 310188,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 484,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 24576
+              },
+              "dimensions": {
+                "field": "alternate_urls.locale",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "lang_tensor_tensor_count",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 168228,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 101172,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 64,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "title_tiny_embedding",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 16,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "is_mobile",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "host_page_count",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 126976
+              },
+              "dimensions": {
+                "field": "static_snippet",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 411236,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 307852,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 324,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 24576
+              },
+              "dimensions": {
+                "field": "level1_categories",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "domain_page_count",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 414300,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 310280,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 372,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 24576
+              },
+              "dimensions": {
+                "field": "categories",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 135168
+              },
+              "dimensions": {
+                "field": "metatags_title",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 339968
+              },
+              "dimensions": {
+                "field": "content",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 336012,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102912,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 576,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "indegree_ratio",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "title_per_entities",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 346408,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 110540,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 636,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 20480,
+                "content.proton.documentdb.ready.index.disk_usage.average": 135168
+              },
+              "dimensions": {
+                "field": "title",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 135168
+              },
+              "dimensions": {
+                "field": "slug",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 1024,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 512,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "jsonld_published_date",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "title_tiny_embedding_tensor_count",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 113208,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 52980,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 176,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "og_article_content_tier",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "host_trust",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 336012,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102888,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 664,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "title_length",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "total_impressions",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "total_ctr",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 171304,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 36600,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 64,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 12288
+              },
+              "dimensions": {
+                "field": "query_url_stats",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 410883,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 311347,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 264,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 24576
+              },
+              "dimensions": {
+                "field": "og_images.url",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 118784
+              },
+              "dimensions": {
+                "field": "url_query_values",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "related_queries",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335756,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102704,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 564,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "alexa_rank",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335756,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102636,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 576,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "quality_signal_malware_score",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "related_queries_relevance",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 426084,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 286800,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 160,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 20480
+              },
+              "dimensions": {
+                "field": "e5_binary_embedding_next",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "title_tag_length",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 341560,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 105468,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 848,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "url_location",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 16,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "is_important_page",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 336012,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102876,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 592,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "host_rank",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 114840,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 54584,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 176,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "domain_tld_exact",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 135168
+              },
+              "dimensions": {
+                "field": "h1",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 336012,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 103040,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 620,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "url_length",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.job.attribute_flush.average": 0,
+                "content.proton.documentdb.job.memory_index_flush.average": 0,
+                "content.proton.documentdb.job.disk_index_fusion.average": 0,
+                "content.proton.documentdb.job.document_store_flush.average": 0,
+                "content.proton.documentdb.job.document_store_compact.average": 0,
+                "content.proton.documentdb.job.bucket_move.average": 0,
+                "content.proton.documentdb.job.lid_space_compact.average": 0.0000028413647,
+                "content.proton.documentdb.job.removed_documents_prune.average": 0,
+                "content.proton.documentdb.job.total.average": 0.0000028413647,
+                "content.proton.documentdb.attribute.resource_usage.address_space.max": 4.182062e-7,
+                "content.proton.documentdb.attribute.resource_usage.feeding_blocked.max": 0,
+                "content.proton.documentdb.index.memory_usage.allocated_bytes.average": 18089860,
+                "content.proton.documentdb.index.memory_usage.used_bytes.average": 7281720,
+                "content.proton.documentdb.index.memory_usage.dead_bytes.average": 71024,
+                "content.proton.documentdb.index.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.index.docs_in_memory.max": 23,
+                "content.proton.documentdb.index.docs_in_memory.last": 23,
+                "content.proton.documentdb.index.io.search.read_bytes.sum": 0,
+                "content.proton.documentdb.index.io.search.read_bytes.count": 0,
+                "content.proton.documentdb.index.io.search.cached_read_bytes.sum": 0,
+                "content.proton.documentdb.index.io.search.cached_read_bytes.count": 0,
+                "content.proton.documentdb.ready.lid_space.lid_limit.max": 64,
+                "content.proton.documentdb.ready.lid_space.lid_limit.last": 64,
+                "content.proton.documentdb.ready.lid_space.used_lids.max": 63,
+                "content.proton.documentdb.ready.lid_space.used_lids.last": 63,
+                "content.proton.documentdb.ready.lid_space.highest_used_lid.max": 63,
+                "content.proton.documentdb.ready.lid_space.highest_used_lid.last": 63,
+                "content.proton.documentdb.ready.lid_space.lid_bloat_factor.average": 0,
+                "content.proton.documentdb.ready.lid_space.lid_fragmentation_factor.average": 0,
+                "content.proton.documentdb.ready.document_store.disk_usage.average": 1278317,
+                "content.proton.documentdb.ready.document_store.disk_bloat.average": 0,
+                "content.proton.documentdb.ready.document_store.max_bucket_spread.average": 1,
+                "content.proton.documentdb.ready.document_store.memory_usage.allocated_bytes.average": 227012,
+                "content.proton.documentdb.ready.document_store.memory_usage.used_bytes.average": 153656,
+                "content.proton.documentdb.ready.document_store.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.document_store.cache.memory_usage.average": 48,
+                "content.proton.documentdb.ready.document_store.cache.hit_rate.average": 0,
+                "content.proton.documentdb.ready.document_store.cache.lookups.rate": 0,
+                "content.proton.documentdb.ready.document_store.cache.invalidations.rate": 0,
+                "content.proton.documentdb.notready.lid_space.lid_limit.max": 1,
+                "content.proton.documentdb.notready.lid_space.lid_limit.last": 1,
+                "content.proton.documentdb.notready.lid_space.used_lids.max": 0,
+                "content.proton.documentdb.notready.lid_space.used_lids.last": 0,
+                "content.proton.documentdb.notready.lid_space.highest_used_lid.max": 0,
+                "content.proton.documentdb.notready.lid_space.highest_used_lid.last": 0,
+                "content.proton.documentdb.notready.lid_space.lid_bloat_factor.average": 0,
+                "content.proton.documentdb.notready.lid_space.lid_fragmentation_factor.average": 0,
+                "content.proton.documentdb.notready.document_store.disk_usage.average": 12944,
+                "content.proton.documentdb.notready.document_store.disk_bloat.average": 0,
+                "content.proton.documentdb.notready.document_store.max_bucket_spread.average": 1,
+                "content.proton.documentdb.notready.document_store.memory_usage.allocated_bytes.average": 77724,
+                "content.proton.documentdb.notready.document_store.memory_usage.used_bytes.average": 12192,
+                "content.proton.documentdb.notready.document_store.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.notready.document_store.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.notready.document_store.cache.memory_usage.average": 48,
+                "content.proton.documentdb.notready.document_store.cache.hit_rate.average": 0,
+                "content.proton.documentdb.notready.document_store.cache.lookups.rate": 0,
+                "content.proton.documentdb.notready.document_store.cache.invalidations.rate": 0,
+                "content.proton.documentdb.removed.lid_space.lid_limit.max": 1,
+                "content.proton.documentdb.removed.lid_space.lid_limit.last": 1,
+                "content.proton.documentdb.removed.lid_space.used_lids.max": 0,
+                "content.proton.documentdb.removed.lid_space.used_lids.last": 0,
+                "content.proton.documentdb.removed.lid_space.highest_used_lid.max": 0,
+                "content.proton.documentdb.removed.lid_space.highest_used_lid.last": 0,
+                "content.proton.documentdb.removed.lid_space.lid_bloat_factor.average": 0,
+                "content.proton.documentdb.removed.lid_space.lid_fragmentation_factor.average": 0,
+                "content.proton.documentdb.removed.document_store.disk_usage.average": 12944,
+                "content.proton.documentdb.removed.document_store.disk_bloat.average": 0,
+                "content.proton.documentdb.removed.document_store.max_bucket_spread.average": 1,
+                "content.proton.documentdb.removed.document_store.memory_usage.allocated_bytes.average": 85916,
+                "content.proton.documentdb.removed.document_store.memory_usage.used_bytes.average": 12192,
+                "content.proton.documentdb.removed.document_store.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.removed.document_store.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.threading_service.master.accepted.rate": 10.233333,
+                "content.proton.documentdb.threading_service.master.wakeups.rate": 10.033333,
+                "content.proton.documentdb.threading_service.master.utilization.sum": 0.0065019287385,
+                "content.proton.documentdb.threading_service.master.utilization.count": 13,
+                "content.proton.documentdb.threading_service.master.utilization.max": 0.000937808236,
+                "content.proton.documentdb.threading_service.master.queuesize.sum": 322,
+                "content.proton.documentdb.threading_service.master.queuesize.count": 627,
+                "content.proton.documentdb.threading_service.master.queuesize.max": 3,
+                "content.proton.documentdb.threading_service.index.accepted.rate": 0.016666,
+                "content.proton.documentdb.threading_service.index.wakeups.rate": 9.95,
+                "content.proton.documentdb.threading_service.index.utilization.sum": 0.0003357400322,
+                "content.proton.documentdb.threading_service.index.utilization.count": 13,
+                "content.proton.documentdb.threading_service.index.utilization.max": 0.0000350574784,
+                "content.proton.documentdb.threading_service.index.queuesize.sum": 0,
+                "content.proton.documentdb.threading_service.index.queuesize.count": 1,
+                "content.proton.documentdb.threading_service.index.queuesize.max": 0,
+                "content.proton.documentdb.threading_service.summary.accepted.rate": 0.05,
+                "content.proton.documentdb.threading_service.summary.wakeups.rate": 9.95,
+                "content.proton.documentdb.threading_service.summary.utilization.sum": 0.0002926272368,
+                "content.proton.documentdb.threading_service.summary.utilization.count": 13,
+                "content.proton.documentdb.threading_service.summary.utilization.max": 0.0000449753235,
+                "content.proton.documentdb.threading_service.summary.queuesize.sum": 3,
+                "content.proton.documentdb.threading_service.summary.queuesize.count": 3,
+                "content.proton.documentdb.threading_service.summary.queuesize.max": 2,
+                "content.proton.documentdb.matching.docs_matched.count": 0,
+                "content.proton.documentdb.matching.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.queries.rate": 0,
+                "content.proton.documentdb.matching.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.query_latency.sum": 0,
+                "content.proton.documentdb.matching.query_latency.count": 0,
+                "content.proton.documentdb.matching.query_latency.max": 0,
+                "content.proton.documentdb.documents.active.max": 63,
+                "content.proton.documentdb.documents.active.last": 63,
+                "content.proton.documentdb.documents.ready.max": 63,
+                "content.proton.documentdb.documents.ready.last": 63,
+                "content.proton.documentdb.documents.total.max": 63,
+                "content.proton.documentdb.documents.total.last": 63,
+                "content.proton.documentdb.documents.removed.max": 0,
+                "content.proton.documentdb.documents.removed.last": 0,
+                "content.proton.documentdb.bucket_move.buckets_pending.sum": 0,
+                "content.proton.documentdb.bucket_move.buckets_pending.max": 0,
+                "content.proton.documentdb.bucket_move.buckets_pending.last": 0,
+                "content.proton.documentdb.feeding.commit.operations.sum": 0,
+                "content.proton.documentdb.feeding.commit.operations.count": 0,
+                "content.proton.documentdb.feeding.commit.operations.rate": 0,
+                "content.proton.documentdb.feeding.commit.operations.max": 0,
+                "content.proton.documentdb.feeding.commit.latency.sum": 0,
+                "content.proton.documentdb.feeding.commit.latency.count": 0,
+                "content.proton.documentdb.feeding.commit.latency.max": 0,
+                "content.proton.documentdb.memory_usage.allocated_bytes.max": 44215197,
+                "content.proton.documentdb.disk_usage.last": 9189005,
+                "content.proton.documentdb.heart_beat_age.min": 0.9265482,
+                "content.proton.documentdb.heart_beat_age.last": 54.209848764,
+                "content.proton.transactionlog.entries.average": 236,
+                "content.proton.transactionlog.disk_usage.average": 1161417,
+                "content.proton.transactionlog.replay_time.max": 0.018006327,
+                "content.proton.transactionlog.replay_time.last": 0.018006327
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 1024,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 512,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "og_article_modified_time",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "domain_mean_content_length",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "url.fragment",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 135168
+              },
+              "dimensions": {
+                "field": "og_sitename",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 341528,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 105532,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 588,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384,
+                "content.proton.documentdb.ready.index.disk_usage.average": 126976
+              },
+              "dimensions": {
+                "field": "related_queries_str",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335564,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102620,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 820,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "og_images_count",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "linked_per_entities",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335628,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102960,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 836,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "url_slash",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335564,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102608,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 804,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "ctr_seen_not_clicked_1m_windowed",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "content_tiny_embedding_tensor_count",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 114840,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 54776,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 176,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "hostname_exact",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 16,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "official",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "host_hits_authority_score",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335564,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102608,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 804,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "ctr_not_seen_not_clicked_7d_windowed",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 185788,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 52028,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 12288
+              },
+              "dimensions": {
+                "field": "categories_tensor",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "vse",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 346256,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 111004,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 636,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 20480
+              },
+              "dimensions": {
+                "field": "url_exact",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "host_hits_hub_score",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "seen_impressions",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.config.generation.last": 17,
+                "content.proton.resource_usage.disk.average": 0.1395278865881,
+                "content.proton.resource_usage.memory.average": 0.0121615323832,
+                "content.proton.resource_usage.disk_usage.total.max": 0.1395279046667,
+                "content.proton.resource_usage.disk_usage.total_utilization.max": 0.1550310051852,
+                "content.proton.resource_usage.disk_usage.transient.max": 0,
+                "content.proton.resource_usage.memory_usage.total.max": 0.0150457024309,
+                "content.proton.resource_usage.memory_usage.total_utilization.max": 0.0167174471454,
+                "content.proton.resource_usage.memory_usage.transient.max": 0.0028830653116,
+                "content.proton.resource_usage.open_file_descriptors.max": 749,
+                "content.proton.resource_usage.feeding_blocked.max": 0,
                 "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0016251285661,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006426285427,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2356.066666
+                "content.proton.resource_usage.malloc_arena.max": 671088640,
+                "content.proton.resource_usage.cpu_util.setup.sum": 0,
+                "content.proton.resource_usage.cpu_util.setup.count": 13,
+                "content.proton.resource_usage.cpu_util.setup.max": 0,
+                "content.proton.resource_usage.cpu_util.read.sum": 0.0042456505447,
+                "content.proton.resource_usage.cpu_util.read.count": 13,
+                "content.proton.resource_usage.cpu_util.read.max": 0.000400397935,
+                "content.proton.resource_usage.cpu_util.write.sum": 0.0526153062307,
+                "content.proton.resource_usage.cpu_util.write.count": 13,
+                "content.proton.resource_usage.cpu_util.write.max": 0.0083253942836,
+                "content.proton.resource_usage.cpu_util.compact.sum": 0.0003835922095,
+                "content.proton.resource_usage.cpu_util.compact.count": 13,
+                "content.proton.resource_usage.cpu_util.compact.max": 0.0003442582079,
+                "content.proton.resource_usage.cpu_util.other.sum": 0.3178401933555,
+                "content.proton.resource_usage.cpu_util.other.count": 13,
+                "content.proton.resource_usage.cpu_util.other.max": 0.0312466410234,
+                "content.proton.executor.proton.accepted.rate": 0,
+                "content.proton.executor.proton.wakeups.rate": 0,
+                "content.proton.executor.proton.utilization.sum": 0,
+                "content.proton.executor.proton.utilization.count": 13,
+                "content.proton.executor.proton.utilization.max": 0,
+                "content.proton.executor.proton.queuesize.sum": 0,
+                "content.proton.executor.proton.queuesize.count": 13,
+                "content.proton.executor.proton.queuesize.max": 0,
+                "content.proton.executor.flush.accepted.rate": 0,
+                "content.proton.executor.flush.wakeups.rate": 0,
+                "content.proton.executor.flush.utilization.sum": 0,
+                "content.proton.executor.flush.utilization.count": 13,
+                "content.proton.executor.flush.utilization.max": 0,
+                "content.proton.executor.flush.queuesize.sum": 0,
+                "content.proton.executor.flush.queuesize.count": 13,
+                "content.proton.executor.flush.queuesize.max": 0,
+                "content.proton.executor.match.accepted.rate": 0,
+                "content.proton.executor.match.wakeups.rate": 0,
+                "content.proton.executor.match.utilization.sum": 0,
+                "content.proton.executor.match.utilization.count": 13,
+                "content.proton.executor.match.utilization.max": 0,
+                "content.proton.executor.match.queuesize.sum": 0,
+                "content.proton.executor.match.queuesize.count": 13,
+                "content.proton.executor.match.queuesize.max": 0,
+                "content.proton.executor.docsum.accepted.rate": 0,
+                "content.proton.executor.docsum.wakeups.rate": 0,
+                "content.proton.executor.docsum.utilization.sum": 0,
+                "content.proton.executor.docsum.utilization.count": 13,
+                "content.proton.executor.docsum.utilization.max": 0,
+                "content.proton.executor.docsum.queuesize.sum": 0,
+                "content.proton.executor.docsum.queuesize.count": 13,
+                "content.proton.executor.docsum.queuesize.max": 0,
+                "content.proton.executor.shared.accepted.rate": 3.883333,
+                "content.proton.executor.shared.wakeups.rate": 3.883333,
+                "content.proton.executor.shared.utilization.sum": 0.0002775689966,
+                "content.proton.executor.shared.utilization.count": 13,
+                "content.proton.executor.shared.utilization.max": 0.0000646315183,
+                "content.proton.executor.shared.queuesize.sum": 246,
+                "content.proton.executor.shared.queuesize.count": 246,
+                "content.proton.executor.shared.queuesize.max": 3,
+                "content.proton.executor.warmup.accepted.rate": 0,
+                "content.proton.executor.warmup.wakeups.rate": 0,
+                "content.proton.executor.warmup.utilization.sum": 0,
+                "content.proton.executor.warmup.utilization.count": 0,
+                "content.proton.executor.warmup.utilization.max": 0,
+                "content.proton.executor.warmup.queuesize.sum": 0,
+                "content.proton.executor.warmup.queuesize.count": 0,
+                "content.proton.executor.warmup.queuesize.max": 0,
+                "content.proton.executor.field_writer.accepted.rate": 4,
+                "content.proton.executor.field_writer.wakeups.rate": 109.65,
+                "content.proton.executor.field_writer.utilization.sum": 0.0006020980323,
+                "content.proton.executor.field_writer.utilization.count": 13,
+                "content.proton.executor.field_writer.utilization.max": 0.0003694117998,
+                "content.proton.executor.field_writer.saturation.sum": 0.0009237859032,
+                "content.proton.executor.field_writer.saturation.count": 13,
+                "content.proton.executor.field_writer.saturation.max": 0.000554959671,
+                "content.proton.executor.field_writer.queuesize.sum": 1200,
+                "content.proton.executor.field_writer.queuesize.count": 240,
+                "content.proton.executor.field_writer.queuesize.max": 109,
+                "content.proton.index.cache.postinglist.memory_usage.average": 0,
+                "content.proton.index.cache.postinglist.hit_rate.average": 0,
+                "content.proton.index.cache.postinglist.lookups.rate": 0,
+                "content.proton.index.cache.postinglist.invalidations.rate": 0,
+                "content.proton.index.cache.bitvector.memory_usage.average": 0,
+                "content.proton.index.cache.bitvector.hit_rate.average": 0,
+                "content.proton.index.cache.bitvector.lookups.rate": 0,
+                "content.proton.index.cache.bitvector.invalidations.rate": 0,
+                "content.proton.docsum.docs.rate": 0,
+                "content.proton.docsum.latency.sum": 0,
+                "content.proton.docsum.latency.count": 0,
+                "content.proton.docsum.latency.max": 0,
+                "content.proton.search_protocol.query.latency.sum": 0,
+                "content.proton.search_protocol.query.latency.count": 0,
+                "content.proton.search_protocol.query.latency.max": 0,
+                "content.proton.search_protocol.query.request_size.sum": 0,
+                "content.proton.search_protocol.query.request_size.count": 0,
+                "content.proton.search_protocol.query.request_size.max": 0,
+                "content.proton.search_protocol.query.reply_size.sum": 0,
+                "content.proton.search_protocol.query.reply_size.count": 0,
+                "content.proton.search_protocol.query.reply_size.max": 0,
+                "content.proton.search_protocol.docsum.latency.average": 0,
+                "content.proton.search_protocol.docsum.latency.sum": 0,
+                "content.proton.search_protocol.docsum.latency.count": 0,
+                "content.proton.search_protocol.docsum.latency.max": 0,
+                "content.proton.search_protocol.docsum.request_size.sum": 0,
+                "content.proton.search_protocol.docsum.request_size.count": 0,
+                "content.proton.search_protocol.docsum.request_size.max": 0,
+                "content.proton.search_protocol.docsum.reply_size.sum": 0,
+                "content.proton.search_protocol.docsum.reply_size.count": 0,
+                "content.proton.search_protocol.docsum.reply_size.max": 0,
+                "content.proton.search_protocol.docsum.requested_documents.count": 0,
+                "vds.server.network.client.tls-connections-established.count": 0,
+                "vds.server.network.client.insecure-connections-established.count": 0,
+                "vds.server.network.server.tls-connections-established.count": 0,
+                "vds.server.network.server.insecure-connections-established.count": 4,
+                "vds.server.network.tls-handshakes-failed.count": 0,
+                "vds.server.network.peer-authorization-failures.count": 0,
+                "vds.server.network.tls-connections-broken.count": 0,
+                "vds.server.network.failed-tls-config-reloads.count": 0,
+                "vds.server.network.rpc-capability-checks-failed.count": 0,
+                "vds.server.network.status-capability-checks-failed.count": 0,
+                "vds.server.fnet.num-connections.count": 1,
+                "vds.bouncer.clock_skew_aborts.count": 0,
+                "vds.mergethrottler.averagequeuewaitingtime.sum": 0,
+                "vds.mergethrottler.averagequeuewaitingtime.count": 0,
+                "vds.mergethrottler.averagequeuewaitingtime.max": 0,
+                "vds.mergethrottler.queuesize.sum": 0,
+                "vds.mergethrottler.queuesize.count": 0,
+                "vds.mergethrottler.queuesize.max": 0,
+                "vds.mergethrottler.active_window_size.sum": 0,
+                "vds.mergethrottler.active_window_size.count": 0,
+                "vds.mergethrottler.active_window_size.max": 0,
+                "vds.mergethrottler.estimated_merge_memory_usage.sum": 0,
+                "vds.mergethrottler.estimated_merge_memory_usage.count": 0,
+                "vds.mergethrottler.estimated_merge_memory_usage.max": 0,
+                "vds.mergethrottler.bounced_due_to_back_pressure.rate": 0,
+                "vds.mergethrottler.mergechains.ok.rate": 0,
+                "vds.mergethrottler.mergechains.failures.total.rate": 0,
+                "vds.mergethrottler.mergechains.failures.busy.rate": 0,
+                "vds.mergethrottler.locallyexecutedmerges.ok.rate": 0,
+                "vds.datastored.alldisks.buckets.average": 11,
+                "vds.datastored.alldisks.docs.average": 63,
+                "vds.datastored.alldisks.bytes.average": 902849,
+                "vds.visitor.allthreads.queuesize.sum": 0,
+                "vds.visitor.allthreads.queuesize.count": 208,
+                "vds.visitor.allthreads.queuesize.max": 0,
+                "vds.visitor.allthreads.averagequeuewait.sum": 0,
+                "vds.visitor.allthreads.averagequeuewait.count": 0,
+                "vds.visitor.allthreads.averagequeuewait.max": 0,
+                "vds.visitor.allthreads.averagevisitorlifetime.sum": 0,
+                "vds.visitor.allthreads.averagevisitorlifetime.count": 0,
+                "vds.visitor.allthreads.averagevisitorlifetime.max": 0,
+                "vds.visitor.allthreads.averagemessagesendtime.sum": 0,
+                "vds.visitor.allthreads.averagemessagesendtime.count": 0,
+                "vds.visitor.allthreads.averagemessagesendtime.max": 0,
+                "vds.visitor.allthreads.averageprocessingtime.sum": 0,
+                "vds.visitor.allthreads.averageprocessingtime.count": 0,
+                "vds.visitor.allthreads.averageprocessingtime.max": 0,
+                "vds.visitor.allthreads.created.rate": 0,
+                "vds.visitor.allthreads.completed.rate": 0,
+                "vds.visitor.allthreads.failed.rate": 0,
+                "vds.filestor.allthreads.put.count.rate": 0,
+                "vds.filestor.allthreads.put.latency.sum": 0,
+                "vds.filestor.allthreads.put.latency.count": 0,
+                "vds.filestor.allthreads.put.latency.max": 0,
+                "vds.filestor.allthreads.put.failed.rate": 0,
+                "vds.filestor.allthreads.put.request_size.sum": 0,
+                "vds.filestor.allthreads.put.request_size.count": 0,
+                "vds.filestor.allthreads.put.request_size.max": 0,
+                "vds.filestor.allthreads.put.test_and_set_failed.rate": 0,
+                "vds.filestor.allthreads.get.count.rate": 0,
+                "vds.filestor.allthreads.get.latency.sum": 0,
+                "vds.filestor.allthreads.get.latency.count": 0,
+                "vds.filestor.allthreads.get.latency.max": 0,
+                "vds.filestor.allthreads.get.failed.rate": 0,
+                "vds.filestor.allthreads.get.request_size.sum": 0,
+                "vds.filestor.allthreads.get.request_size.count": 0,
+                "vds.filestor.allthreads.get.request_size.max": 0,
+                "vds.filestor.allthreads.remove.count.rate": 0,
+                "vds.filestor.allthreads.remove.latency.sum": 0,
+                "vds.filestor.allthreads.remove.latency.count": 0,
+                "vds.filestor.allthreads.remove.latency.max": 0,
+                "vds.filestor.allthreads.remove.failed.rate": 0,
+                "vds.filestor.allthreads.remove.request_size.sum": 0,
+                "vds.filestor.allthreads.remove.request_size.count": 0,
+                "vds.filestor.allthreads.remove.request_size.max": 0,
+                "vds.filestor.allthreads.remove.test_and_set_failed.rate": 0,
+                "vds.filestor.allthreads.remove_location.count.rate": 0,
+                "vds.filestor.allthreads.remove_location.latency.sum": 0,
+                "vds.filestor.allthreads.remove_location.latency.count": 0,
+                "vds.filestor.allthreads.remove_location.latency.max": 0,
+                "vds.filestor.allthreads.update.count.rate": 0,
+                "vds.filestor.allthreads.update.latency.sum": 0,
+                "vds.filestor.allthreads.update.latency.count": 0,
+                "vds.filestor.allthreads.update.latency.max": 0,
+                "vds.filestor.allthreads.update.failed.rate": 0,
+                "vds.filestor.allthreads.update.request_size.sum": 0,
+                "vds.filestor.allthreads.update.request_size.count": 0,
+                "vds.filestor.allthreads.update.request_size.max": 0,
+                "vds.filestor.allthreads.update.test_and_set_failed.rate": 0,
+                "vds.filestor.allthreads.createiterator.count.rate": 0,
+                "vds.filestor.allthreads.createiterator.latency.sum": 0,
+                "vds.filestor.allthreads.createiterator.latency.count": 0,
+                "vds.filestor.allthreads.createiterator.latency.max": 0,
+                "vds.filestor.allthreads.visit.count.rate": 0,
+                "vds.filestor.allthreads.visit.latency.sum": 0,
+                "vds.filestor.allthreads.visit.latency.count": 0,
+                "vds.filestor.allthreads.visit.latency.max": 0,
+                "vds.filestor.allthreads.deletebuckets.count.rate": 0,
+                "vds.filestor.allthreads.deletebuckets.latency.sum": 0,
+                "vds.filestor.allthreads.deletebuckets.latency.count": 0,
+                "vds.filestor.allthreads.deletebuckets.latency.max": 0,
+                "vds.filestor.allthreads.deletebuckets.failed.rate": 0,
+                "vds.filestor.allthreads.remove_by_gid.count.rate": 0,
+                "vds.filestor.allthreads.remove_by_gid.latency.sum": 0,
+                "vds.filestor.allthreads.remove_by_gid.latency.count": 0,
+                "vds.filestor.allthreads.remove_by_gid.latency.max": 0,
+                "vds.filestor.allthreads.remove_by_gid.failed.rate": 0,
+                "vds.filestor.allthreads.splitbuckets.count.rate": 0,
+                "vds.filestor.allthreads.joinbuckets.count.rate": 0,
+                "vds.filestor.allthreads.setbucketstates.count.rate": 0,
+                "vds.filestor.allthreads.mergemetadatareadlatency.sum": 0,
+                "vds.filestor.allthreads.mergemetadatareadlatency.count": 0,
+                "vds.filestor.allthreads.mergemetadatareadlatency.max": 0,
+                "vds.filestor.allthreads.mergedatareadlatency.sum": 0,
+                "vds.filestor.allthreads.mergedatareadlatency.count": 0,
+                "vds.filestor.allthreads.mergedatareadlatency.max": 0,
+                "vds.filestor.allthreads.mergedatawritelatency.sum": 0,
+                "vds.filestor.allthreads.mergedatawritelatency.count": 0,
+                "vds.filestor.allthreads.mergedatawritelatency.max": 0,
+                "vds.filestor.allthreads.merge_put_latency.sum": 0,
+                "vds.filestor.allthreads.merge_put_latency.count": 0,
+                "vds.filestor.allthreads.merge_put_latency.max": 0,
+                "vds.filestor.allthreads.merge_remove_latency.sum": 0,
+                "vds.filestor.allthreads.merge_remove_latency.count": 0,
+                "vds.filestor.allthreads.merge_remove_latency.max": 0,
+                "vds.filestor.allstripes.throttled_rpc_direct_dispatches.rate": 0,
+                "vds.filestor.allstripes.throttled_persistence_thread_polls.rate": 0,
+                "vds.filestor.allstripes.timeouts_waiting_for_throttle_token.rate": 0,
+                "vds.filestor.averagequeuewait.sum": 0,
+                "vds.filestor.averagequeuewait.count": 0,
+                "vds.filestor.averagequeuewait.max": 0,
+                "vds.filestor.queuesize.sum": 0,
+                "vds.filestor.queuesize.count": 13,
+                "vds.filestor.queuesize.max": 0,
+                "vds.filestor.throttle_window_size.sum": 260,
+                "vds.filestor.throttle_window_size.count": 13,
+                "vds.filestor.throttle_window_size.max": 20,
+                "vds.filestor.throttle_waiting_threads.sum": 0,
+                "vds.filestor.throttle_waiting_threads.count": 13,
+                "vds.filestor.throttle_waiting_threads.max": 0,
+                "vds.filestor.throttle_active_tokens.sum": 0,
+                "vds.filestor.throttle_active_tokens.count": 13,
+                "vds.filestor.throttle_active_tokens.max": 0,
+                "vds.filestor.active_operations.size.sum": 0,
+                "vds.filestor.active_operations.size.count": 0,
+                "vds.filestor.active_operations.size.max": 0,
+                "vds.filestor.active_operations.latency.sum": 0,
+                "vds.filestor.active_operations.latency.count": 0,
+                "vds.filestor.active_operations.latency.max": 0
               },
               "dimensions": {
                 "serviceId": "searchnode"
@@ -9119,41 +3299,1587 @@
             },
             {
               "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 15475.966666,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10320301,
-                "content.proton.documentdb.documents.ready.last": 10320301,
-                "content.proton.documentdb.documents.total.last": 10320301,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66647084686,
-                "content.proton.documentdb.disk_usage.last": 14620686062,
-                "content.proton.transactionlog.disk_usage.last": 3160848965
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 16,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
               },
               "dimensions": {
-                "documenttype": "def",
+                "field": "login",
+                "documenttype": "web",
                 "serviceId": "searchnode"
               }
             },
             {
               "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002673305901,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0023126330481
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
               },
               "dimensions": {
-                "rankProfile": "sparse_abc_linear",
-                "documenttype": "def",
+                "documenttype": "web",
+                "rankProfile": "web_curent",
                 "serviceId": "searchnode"
               }
             },
             {
               "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
               },
               "dimensions": {
+                "field": "h1_stem",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 114656,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 54408,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 176,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "domain_exact",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 336012,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102956,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 588,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "tranco_rank",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "title_loc_entities",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "subdomains_count",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 341560,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 105432,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 840,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "lang",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335564,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102644,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 812,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "ctr_not_seen_not_clicked_1m_windowed",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 1024,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 512,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "og_article_published_time",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 406680,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 306648,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 208,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 20480
+              },
+              "dimensions": {
+                "field": "linked_per_entities_docs_id",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "shingle_related_queries",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "content_tiny_embedding_next_tensor_count",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 135168
+              },
+              "dimensions": {
+                "field": "t_anchor",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 1024,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 512,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "published_date_rss",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 126976
+              },
+              "dimensions": {
+                "field": "og_article_author",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "hits_authority_score",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "e5_binary_embedding_next_tensor_count",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 159744
+              },
+              "dimensions": {
+                "field": "url.hostname",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 1024,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 512,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "last_modified",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 16,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "is_soft_404",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 341528,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 104920,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 596,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "doc_type",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 336012,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 103068,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 616,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "total_links_count",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "related_queries_tiny_embedding_tensor_count",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 1024,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 512,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "download_duration_ms",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 336012,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 103092,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 608,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "content_length",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
                 "rankProfile": "default",
-                "documenttype": "abc",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335628,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102356,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 632,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "content_highlighted_length",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 135168
+              },
+              "dimensions": {
+                "field": "domain",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 135168
+              },
+              "dimensions": {
+                "field": "domain_tld",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 168228,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102900,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 1024,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "title_tiny_embedding_next",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 16,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "is_wikipedia",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335628,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102236,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 580,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "ctr_not_seen_not_clicked_3m_windowed",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "generated_queries",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 457032,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 447164,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 188,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "query_url_stats_v2",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 426233,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 318477,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 616,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 28672
+              },
+              "dimensions": {
+                "field": "content_highlighted",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 341528,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 104864,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 576,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "id",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "domain_mean_title_length",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "web_new",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 455032,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 444676,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 492,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "level1_categories_tensor",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "metatags_description_stem",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "level1_categories_tensor_tensor_count",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 159744
+              },
+              "dimensions": {
+                "field": "url.scheme",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 341752,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 105664,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 876,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "tld",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "pagerank_pregel",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "selected_anchors",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 1024,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 512,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "last_update_date",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 120312,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 29040,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 200,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192,
+                "content.proton.documentdb.notready.attribute.memory_usage.allocated_bytes.average": 339880,
+                "content.proton.documentdb.notready.attribute.memory_usage.used_bytes.average": 31028,
+                "content.proton.documentdb.notready.attribute.memory_usage.dead_bytes.average": 332,
+                "content.proton.documentdb.notready.attribute.memory_usage.onhold_bytes.average": 0
+              },
+              "dimensions": {
+                "field": "[documentmetastore]",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "e5_binary_embedding_tensor_count",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 159744
+              },
+              "dimensions": {
+                "field": "metatags_description",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 147456
+              },
+              "dimensions": {
+                "field": "og_description",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "title_tiny_embedding_next_tensor_count",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "web_integration_rank1_model_features",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "title_date_entities",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "unranked",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 16,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "is_ecommerce",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 233764,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 107060,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 2048,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 12288
+              },
+              "dimensions": {
+                "field": "content_tiny_embedding_next",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "web_integration_rank2_model_features",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 341624,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 106132,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 1120,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "og_type",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 118784
+              },
+              "dimensions": {
+                "field": "url.query",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "web_integration_rank2_federation_model_features",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 168228,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 99380,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "related_queries_tiny_embedding",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335564,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102644,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 804,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "ctr_seen_not_clicked_3m_windowed",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 336524,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 103120,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 604,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "click_probability",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "update_count",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 408937,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 309369,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 208,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 24576
+              },
+              "dimensions": {
+                "field": "sitelinks.text",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "query_url_stats_v2_tensor_count",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "doc_queries",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 159744
+              },
+              "dimensions": {
+                "field": "url",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "categories_tensor_tensor_count",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 294240,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 253924,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 32,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 12288
+              },
+              "dimensions": {
+                "field": "title_date_timestamp_entities",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "hits_hub_score",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "query_url_stats_tensor_count",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 408520,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 307568,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 304,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 24576
+              },
+              "dimensions": {
+                "field": "jsonld_entities",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 336012,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 103020,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 624,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "quality_signal_spam_score",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 16,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "homepage_from_url",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 1024,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 512,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "fetch_time",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 90112
+              },
+              "dimensions": {
+                "field": "related_queries_array",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 294256,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 253940,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 32,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "url_timestamps",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 113432,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 53108,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 176,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "og_locale",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335516,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102036,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 544,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "trust_rank",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 343960,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 108880,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 628,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "og_url",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 143360
+              },
+              "dimensions": {
+                "field": "url.host",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 16,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "root_url",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "shingle_related_queries_relevance",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 143360
+              },
+              "dimensions": {
+                "field": "parsed_url",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 110592
+              },
+              "dimensions": {
+                "field": "url.port",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 16,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "ssl",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 135168
+              },
+              "dimensions": {
+                "field": "metatags_keywords",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 406680,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 306648,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 208,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 20480
+              },
+              "dimensions": {
+                "field": "linked_loc_entities_docs_id",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 341560,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 105428,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 836,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "url_extension",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 16,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "adult",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.matching.rank_profile.docs_matched.count": 0,
+                "content.proton.documentdb.matching.rank_profile.docs_matched.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.limited_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": 0,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": 6.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": 13,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": 0.5,
+                "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": 0.5,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.grouping_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.rerank_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_setup_time.max": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.sum": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.count": 0,
+                "content.proton.documentdb.matching.rank_profile.query_latency.max": 0
+              },
+              "dimensions": {
+                "documenttype": "web",
+                "rankProfile": "root",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 295072,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 254140,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 88,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "og_images.height",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 768,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 256,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 8192
+              },
+              "dimensions": {
+                "field": "host_mean_title_length",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 341592,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 105564,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 848,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "url_content_type",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 406700,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 307012,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 208,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 24576
+              },
+              "dimensions": {
+                "field": "sitelinks.title",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 135168
+              },
+              "dimensions": {
+                "field": "url_parsed_path",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.index.disk_usage.average": 135168
+              },
+              "dimensions": {
+                "field": "h2",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 406700,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 307004,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 208,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 24576
+              },
+              "dimensions": {
+                "field": "sitelinks.url",
+                "documenttype": "web",
+                "serviceId": "searchnode"
+              }
+            },
+            {
+              "values": {
+                "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": 335532,
+                "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": 102584,
+                "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": 804,
+                "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": 0,
+                "content.proton.documentdb.ready.attribute.disk_usage.average": 16384
+              },
+              "dimensions": {
+                "field": "ctr_seen_not_clicked_7d_windowed",
+                "documenttype": "web",
                 "serviceId": "searchnode"
               }
             }
@@ -9161,7 +4887,7 @@
         },
         {
           "name": "vespa.distributor",
-          "timestamp": 1699277293,
+          "timestamp": 1760044773,
           "status": {
             "code": "up",
             "description": "Data collected successfully"
@@ -9169,315 +4895,120 @@
           "metrics": [
             {
               "values": {
-                "memory_virt": 453775360,
-                "memory_rss": 243032064,
-                "cpu": 11.3417721518987,
-                "cpu_util": 0.3544303797468
+                "memory_virt": 504274944,
+                "memory_rss": 36876288,
+                "cpu": 3.9838558691282,
+                "cpu_util": 0.3621687153753
               },
               "dimensions": {
                 "serviceId": "distributor"
               }
             },
             {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277293,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
               "values": {
-                "memory_virt": 984985600,
-                "memory_rss": 300367872,
-                "cpu": 0.4677019444082,
-                "cpu_util": 0.0146156857628
+                "vds.server.network.client.tls-connections-established.count": 0,
+                "vds.server.network.client.insecure-connections-established.count": 0,
+                "vds.server.network.server.tls-connections-established.count": 0,
+                "vds.server.network.server.insecure-connections-established.count": 4,
+                "vds.server.network.tls-handshakes-failed.count": 0,
+                "vds.server.network.peer-authorization-failures.count": 0,
+                "vds.server.network.tls-connections-broken.count": 0,
+                "vds.server.network.failed-tls-config-reloads.count": 0,
+                "vds.server.network.rpc-capability-checks-failed.count": 0,
+                "vds.server.network.status-capability-checks-failed.count": 0,
+                "vds.server.fnet.num-connections.count": 1,
+                "vds.bouncer.clock_skew_aborts.count": 0,
+                "vds.distributor.puts.latency.sum": 0,
+                "vds.distributor.puts.latency.count": 0,
+                "vds.distributor.puts.latency.max": 0,
+                "vds.distributor.puts.ok.rate": 0,
+                "vds.distributor.puts.failures.total.rate": 0,
+                "vds.distributor.puts.failures.notready.rate": 0,
+                "vds.distributor.puts.failures.notconnected.rate": 0,
+                "vds.distributor.puts.failures.wrongdistributor.rate": 0,
+                "vds.distributor.puts.failures.safe_time_not_reached.rate": 0,
+                "vds.distributor.puts.failures.storagefailure.rate": 0,
+                "vds.distributor.puts.failures.timeout.rate": 0,
+                "vds.distributor.puts.failures.busy.rate": 0,
+                "vds.distributor.puts.failures.inconsistent_bucket.rate": 0,
+                "vds.distributor.puts.failures.notfound.rate": 0,
+                "vds.distributor.puts.failures.concurrent_mutations.rate": 0,
+                "vds.distributor.puts.failures.test_and_set_failed.rate": 0,
+                "vds.distributor.updates.latency.sum": 0,
+                "vds.distributor.updates.latency.count": 0,
+                "vds.distributor.updates.latency.max": 0,
+                "vds.distributor.updates.ok.rate": 0,
+                "vds.distributor.updates.failures.total.rate": 0,
+                "vds.distributor.updates.failures.notfound.rate": 0,
+                "vds.distributor.updates.failures.concurrent_mutations.rate": 0,
+                "vds.distributor.updates.failures.test_and_set_failed.rate": 0,
+                "vds.distributor.updates.diverging_timestamp_updates.rate": 0,
+                "vds.distributor.removes.latency.sum": 0,
+                "vds.distributor.removes.latency.count": 0,
+                "vds.distributor.removes.latency.max": 0,
+                "vds.distributor.removes.ok.rate": 0,
+                "vds.distributor.removes.failures.total.rate": 0,
+                "vds.distributor.removes.failures.notfound.rate": 0,
+                "vds.distributor.removes.failures.concurrent_mutations.rate": 0,
+                "vds.distributor.removes.failures.test_and_set_failed.rate": 0,
+                "vds.distributor.removelocations.ok.rate": 0,
+                "vds.distributor.removelocations.failures.total.rate": 0,
+                "vds.distributor.gets.latency.sum": 0,
+                "vds.distributor.gets.latency.count": 0,
+                "vds.distributor.gets.latency.max": 0,
+                "vds.distributor.gets.ok.rate": 0,
+                "vds.distributor.gets.failures.total.rate": 0,
+                "vds.distributor.gets.failures.notfound.rate": 0,
+                "vds.distributor.visitor.latency.sum": 0,
+                "vds.distributor.visitor.latency.count": 0,
+                "vds.distributor.visitor.latency.max": 0,
+                "vds.distributor.visitor.ok.rate": 0,
+                "vds.distributor.visitor.failures.total.rate": 0,
+                "vds.distributor.visitor.failures.notready.rate": 0,
+                "vds.distributor.visitor.failures.notconnected.rate": 0,
+                "vds.distributor.visitor.failures.wrongdistributor.rate": 0,
+                "vds.distributor.visitor.failures.safe_time_not_reached.rate": 0,
+                "vds.distributor.visitor.failures.storagefailure.rate": 0,
+                "vds.distributor.visitor.failures.timeout.rate": 0,
+                "vds.distributor.visitor.failures.busy.rate": 0,
+                "vds.distributor.visitor.failures.inconsistent_bucket.rate": 0,
+                "vds.distributor.visitor.failures.notfound.rate": 0,
+                "vds.distributor.docsstored.average": 63,
+                "vds.distributor.bytesstored.average": 902849,
+                "vds.idealstate.idealstate_diff.average": 0,
+                "vds.idealstate.buckets_toofewcopies.average": 0,
+                "vds.idealstate.buckets_toomanycopies.average": 0,
+                "vds.idealstate.buckets.average": 11,
+                "vds.idealstate.buckets_notrusted.average": 0,
+                "vds.idealstate.buckets_rechecking.average": 0,
+                "vds.idealstate.bucket_replicas_moving_out.average": 0,
+                "vds.idealstate.bucket_replicas_copying_in.average": 0,
+                "vds.idealstate.bucket_replicas_copying_out.average": 0,
+                "vds.idealstate.bucket_replicas_syncing.average": 0,
+                "vds.idealstate.max_observed_time_since_last_gc_sec.average": 0,
+                "vds.idealstate.delete_bucket.pending.average": 0,
+                "vds.idealstate.delete_bucket.done_ok.rate": 0,
+                "vds.idealstate.delete_bucket.done_failed.rate": 0,
+                "vds.idealstate.merge_bucket.pending.average": 0,
+                "vds.idealstate.merge_bucket.done_ok.rate": 0,
+                "vds.idealstate.merge_bucket.done_failed.rate": 0,
+                "vds.idealstate.merge_bucket.blocked.rate": 0,
+                "vds.idealstate.merge_bucket.throttled.rate": 0,
+                "vds.idealstate.merge_bucket.source_only_copy_changed.rate": 0,
+                "vds.idealstate.merge_bucket.source_only_copy_delete_blocked.rate": 0,
+                "vds.idealstate.merge_bucket.source_only_copy_delete_failed.rate": 0,
+                "vds.idealstate.split_bucket.pending.average": 0,
+                "vds.idealstate.split_bucket.done_ok.rate": 0,
+                "vds.idealstate.split_bucket.done_failed.rate": 0,
+                "vds.idealstate.join_bucket.pending.average": 0,
+                "vds.idealstate.join_bucket.done_ok.rate": 0,
+                "vds.idealstate.join_bucket.done_failed.rate": 0,
+                "vds.idealstate.garbage_collection.pending.average": 0,
+                "vds.idealstate.garbage_collection.done_ok.rate": 0,
+                "vds.idealstate.garbage_collection.done_failed.rate": 0,
+                "vds.idealstate.garbage_collection.documents_removed.count": 0,
+                "vds.idealstate.garbage_collection.documents_removed.rate": 0
               },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0033333333333
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 2
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 42318666.666666664
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277293,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277293,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 16920576,
-                "cpu": 0.2839618948193,
-                "cpu_util": 0.0088738092131
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277283,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 73239474176,
-                "memory_rss": 67911491584,
-                "cpu": 69.2984888033352,
-                "cpu_util": 2.1655777751042
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.15,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 11,
-                "content.proton.documentdb.documents.ready.last": 11,
-                "content.proton.documentdb.documents.total.last": 11,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 11136592,
-                "content.proton.documentdb.disk_usage.last": 3961874,
-                "content.proton.transactionlog.disk_usage.last": 2973538
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001186842753,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.000029671012
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "sparse_def_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.1958590760389,
-                "content.proton.resource_usage.memory.average": 0.4988045633312,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0016786761749,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006762852688,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2644.966666
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 18353.4,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10325581,
-                "content.proton.documentdb.documents.ready.last": 10325581,
-                "content.proton.documentdb.documents.total.last": 10325581,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66863964516,
-                "content.proton.documentdb.disk_usage.last": 14670878895,
-                "content.proton.transactionlog.disk_usage.last": 3123491278
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.000250786103,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0024551417217
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "sparse_abc_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277283,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 457969664,
-                "memory_rss": 247287808,
-                "cpu": 11.4158380105977,
-                "cpu_util": 0.3567449378312
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
               "dimensions": {
                 "serviceId": "distributor"
               }
@@ -9486,7 +5017,7 @@
         },
         {
           "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277283,
+          "timestamp": 1760044773,
           "status": {
             "code": "up",
             "description": "Data collected successfully"
@@ -9494,10 +5025,10 @@
           "metrics": [
             {
               "values": {
-                "memory_virt": 979345408,
-                "memory_rss": 319639552,
-                "cpu": 0.5523792585773,
-                "cpu_util": 0.0172618518305
+                "memory_virt": 949956608,
+                "memory_rss": 221556736,
+                "cpu": 2.2620198578948,
+                "cpu_util": 0.2056381688995
               },
               "dimensions": {
                 "serviceId": "metricsproxy-container"
@@ -9505,7 +5036,134 @@
             },
             {
               "values": {
-                "serverActiveThreads.average": 0.0133555926544
+                "serverActiveThreads.sum": 5,
+                "serverActiveThreads.count": 597,
+                "serverActiveThreads.last": 0,
+                "serverActiveThreads.max": 1,
+                "serverActiveThreads.min": 0,
+                "serverThreadPoolSize.last": 1,
+                "serverThreadPoolSize.max": 1,
+                "jdisc.thread_pool.work_queue.capacity.sum": 29850,
+                "jdisc.thread_pool.work_queue.capacity.count": 597,
+                "jdisc.thread_pool.work_queue.capacity.last": 50,
+                "jdisc.thread_pool.work_queue.capacity.max": 50,
+                "jdisc.thread_pool.work_queue.capacity.min": 50,
+                "jdisc.thread_pool.work_queue.size.sum": 0,
+                "jdisc.thread_pool.work_queue.size.count": 597,
+                "jdisc.thread_pool.work_queue.size.last": 0,
+                "jdisc.thread_pool.work_queue.size.max": 0,
+                "jdisc.thread_pool.work_queue.size.min": 0,
+                "jdisc.thread_pool.max_allowed_size.sum": 597,
+                "jdisc.thread_pool.max_allowed_size.count": 597,
+                "jdisc.thread_pool.max_allowed_size.last": 1,
+                "jdisc.thread_pool.max_allowed_size.max": 1,
+                "jdisc.thread_pool.max_allowed_size.min": 1,
+                "jdisc.thread_pool.active_threads.sum": 5,
+                "jdisc.thread_pool.active_threads.count": 597,
+                "jdisc.thread_pool.active_threads.last": 0,
+                "jdisc.thread_pool.active_threads.max": 1,
+                "jdisc.thread_pool.active_threads.min": 0,
+                "jdisc.thread_pool.size.sum": 597,
+                "jdisc.thread_pool.size.count": 597,
+                "jdisc.thread_pool.size.last": 1,
+                "jdisc.thread_pool.size.max": 1,
+                "jdisc.thread_pool.size.min": 1
+              },
+              "dimensions": {
+                "threadpool": "default-pool",
+                "serviceId": "metricsproxy-container"
+              }
+            },
+            {
+              "values": {
+                "serverActiveThreads.sum": 0,
+                "serverActiveThreads.count": 597,
+                "serverActiveThreads.last": 0,
+                "serverActiveThreads.max": 0,
+                "serverActiveThreads.min": 0,
+                "serverThreadPoolSize.last": 8,
+                "serverThreadPoolSize.max": 8,
+                "jdisc.thread_pool.work_queue.capacity.sum": 388050,
+                "jdisc.thread_pool.work_queue.capacity.count": 597,
+                "jdisc.thread_pool.work_queue.capacity.last": 650,
+                "jdisc.thread_pool.work_queue.capacity.max": 650,
+                "jdisc.thread_pool.work_queue.capacity.min": 650,
+                "jdisc.thread_pool.work_queue.size.sum": 0,
+                "jdisc.thread_pool.work_queue.size.count": 597,
+                "jdisc.thread_pool.work_queue.size.last": 0,
+                "jdisc.thread_pool.work_queue.size.max": 0,
+                "jdisc.thread_pool.work_queue.size.min": 0,
+                "jdisc.thread_pool.max_allowed_size.sum": 4776,
+                "jdisc.thread_pool.max_allowed_size.count": 597,
+                "jdisc.thread_pool.max_allowed_size.last": 8,
+                "jdisc.thread_pool.max_allowed_size.max": 8,
+                "jdisc.thread_pool.max_allowed_size.min": 8,
+                "jdisc.thread_pool.active_threads.sum": 0,
+                "jdisc.thread_pool.active_threads.count": 597,
+                "jdisc.thread_pool.active_threads.last": 0,
+                "jdisc.thread_pool.active_threads.max": 0,
+                "jdisc.thread_pool.active_threads.min": 0,
+                "jdisc.thread_pool.size.sum": 4776,
+                "jdisc.thread_pool.size.count": 597,
+                "jdisc.thread_pool.size.last": 8,
+                "jdisc.thread_pool.size.max": 8,
+                "jdisc.thread_pool.size.min": 8
+              },
+              "dimensions": {
+                "threadpool": "default-handler-common",
+                "serviceId": "metricsproxy-container"
+              }
+            },
+            {
+              "values": {
+                "mem.direct.free.average": 0,
+                "mem.native.free.average": 23304338756949.3,
+                "jdisc.http.jetty.threadpool.thread.total.sum": 120,
+                "jdisc.http.jetty.threadpool.thread.total.count": 30,
+                "jdisc.http.jetty.threadpool.thread.total.last": 4,
+                "jdisc.http.jetty.threadpool.thread.total.max": 4,
+                "jdisc.http.jetty.threadpool.thread.total.min": 4,
+                "jdisc.open_file_descriptors.max": 119,
+                "mem.heap.total.average": 103809024,
+                "mem.direct.used.average": 1096012,
+                "mem.direct.used.max": 1096197,
+                "mem.native.used.average": 24687625808554.7,
+                "jdisc.tls.capability_checks.failed.rate": 0,
+                "jdisc.http.jetty.threadpool.thread.busy.sum": 60,
+                "jdisc.http.jetty.threadpool.thread.busy.count": 30,
+                "jdisc.http.jetty.threadpool.thread.busy.last": 2,
+                "jdisc.http.jetty.threadpool.thread.busy.max": 2,
+                "jdisc.http.jetty.threadpool.thread.busy.min": 2,
+                "jdisc.deactivated_containers.total.sum": 0,
+                "jdisc.deactivated_containers.total.last": 0,
+                "mem.direct.total.average": 1096012,
+                "jdisc.memory_mappings.max": 336,
+                "jdisc.http.jetty.threadpool.thread.max.sum": 120,
+                "jdisc.http.jetty.threadpool.thread.max.count": 30,
+                "jdisc.http.jetty.threadpool.thread.max.last": 4,
+                "jdisc.http.jetty.threadpool.thread.max.max": 4,
+                "jdisc.http.jetty.threadpool.thread.max.min": 4,
+                "jdisc.http.jetty.threadpool.thread.reserved.sum": -30,
+                "jdisc.http.jetty.threadpool.thread.reserved.count": 30,
+                "jdisc.http.jetty.threadpool.thread.reserved.last": -1,
+                "jdisc.http.jetty.threadpool.thread.reserved.max": -1,
+                "jdisc.http.jetty.threadpool.thread.reserved.min": -1,
+                "mem.heap.used.average": 62134378.6666667,
+                "mem.heap.used.max": 78765728,
+                "mem.native.total.average": 47991964565504,
+                "jdisc.tls.capability_checks.succeeded.rate": 0,
+                "mem.direct.count.max": 19,
+                "jdisc.http.jetty.threadpool.thread.min.sum": 120,
+                "jdisc.http.jetty.threadpool.thread.min.count": 30,
+                "jdisc.http.jetty.threadpool.thread.min.last": 4,
+                "jdisc.http.jetty.threadpool.thread.min.max": 4,
+                "jdisc.http.jetty.threadpool.thread.min.min": 4,
+                "mem.heap.free.average": 41674645.3333333,
+                "jdisc.http.jetty.threadpool.queue.size.sum": 0,
+                "jdisc.http.jetty.threadpool.queue.size.count": 30,
+                "jdisc.http.jetty.threadpool.queue.size.last": 0,
+                "jdisc.http.jetty.threadpool.queue.size.max": 0,
+                "jdisc.http.jetty.threadpool.queue.size.min": 0
               },
               "dimensions": {
                 "serviceId": "metricsproxy-container"
@@ -9513,324 +5171,51 @@
             },
             {
               "values": {
-                "jdisc.gc.ms.average": 1
+                "jdisc.jvm.last": 17
               },
               "dimensions": {
-                "gcName": "G1YoungGeneration",
+                "vendor": "Red Hat, Inc.",
                 "serviceId": "metricsproxy-container"
               }
             },
             {
               "values": {
-                "http.status.2xx.rate": 0.1
+                "jdisc.http.request.requests_per_connection.average": 68,
+                "jdisc.http.request.requests_per_connection.sum": 0,
+                "jdisc.http.request.requests_per_connection.count": 0,
+                "jdisc.http.request.requests_per_connection.max": 68,
+                "jdisc.http.request.requests_per_connection.min": 68,
+                "serverNumConnections.average": 62.3,
+                "serverNumConnections.last": 62,
+                "serverNumConnections.max": 63,
+                "serverNumOpenConnections.average": 2.3,
+                "serverNumOpenConnections.last": 2,
+                "serverNumOpenConnections.max": 3
               },
               "dimensions": {
+                "serverName": "SearchServer",
+                "serverPort": "19092",
+                "serviceId": "metricsproxy-container"
+              }
+            },
+            {
+              "values": {
+                "serverBytesSent.sum": 0,
+                "serverBytesSent.count": 150,
+                "jdisc.http.request.uri_length.sum": 285,
+                "jdisc.http.request.uri_length.count": 13,
+                "jdisc.http.request.uri_length.max": 29,
+                "jdisc.http.requests.count": 13,
+                "jdisc.http.requests.rate": 0.216670277838,
+                "jdisc.http.request.content_size.sum": 0,
+                "jdisc.http.request.content_size.count": 13,
+                "jdisc.http.request.content_size.max": 0
+              },
+              "dimensions": {
+                "serverPort": "19092",
+                "serverName": "SearchServer",
+                "protocol": "HTTP/1.1",
                 "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 43592894.666666664
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277283,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277283,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 16773120,
-                "cpu": 0.2845590119944,
-                "cpu_util": 0.0088924691248
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.configserver",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "configserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "configserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "configserver"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 420533076
-              },
-              "dimensions": {
-                "serviceId": "configserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "configserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "configserver"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.slobrok",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 122511360,
-                "memory_rss": 18333696,
-                "cpu": 1.585579571059,
-                "cpu_util": 0.1981974463824
-              },
-              "dimensions": {
-                "serviceId": "slobrok"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "slobrok"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.container-clustercontroller",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 860327936,
-                "memory_rss": 284573696,
-                "cpu": 2.3199532671284,
-                "cpu_util": 0.2899941583911
-              },
-              "dimensions": {
-                "serviceId": "container-clustercontroller"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "container-clustercontroller"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 3.5
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "container-clustercontroller"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "container-clustercontroller"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 29644681.333333332
-              },
-              "dimensions": {
-                "serviceId": "container-clustercontroller"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "container-clustercontroller"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 988712960,
-                "memory_rss": 294703104,
-                "cpu": 0.8845864975382,
-                "cpu_util": 0.1105733121923
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0066666666667
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 6.5
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166686111435
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 34914209.333333336
-              },
-              "dimensions": {
                 "serviceId": "metricsproxy-container"
               }
             },
@@ -9840,266 +5225,32 @@
               },
               "dimensions": {
                 "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129900544,
-                "memory_rss": 16748544,
-                "cpu": 0.4506384044062,
-                "cpu_util": 0.0563298005508
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277280,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 71277080576,
-                "memory_rss": 67049422848,
-                "cpu": 66.7275012123456,
-                "cpu_util": 2.0852344128858
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.35,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 7,
-                "content.proton.documentdb.documents.ready.last": 7,
-                "content.proton.documentdb.documents.total.last": 7,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 11017560,
-                "content.proton.documentdb.disk_usage.last": 3360414,
-                "content.proton.transactionlog.disk_usage.last": 2545792
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001146164323,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000282712157
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "sparse_def_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.194713006821,
-                "content.proton.resource_usage.memory.average": 0.4954662908408,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0015923711073,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006484568297,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2849.833333
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 18915.683333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10320619,
-                "content.proton.documentdb.documents.ready.last": 10320619,
-                "content.proton.documentdb.documents.total.last": 10320619,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66970907554,
-                "content.proton.documentdb.disk_usage.last": 14716611329,
-                "content.proton.transactionlog.disk_usage.last": 3091455143
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002520694813,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0023140436088
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "sparse_abc_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277280,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 407638016,
-                "memory_rss": 196812800,
-                "cpu": 11.6969188171679,
-                "cpu_util": 0.3655287130365
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277280,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 977711104,
-                "memory_rss": 311689216,
-                "cpu": 0.5172674512585,
-                "cpu_util": 0.0161646078518
-              },
-              "dimensions": {
+                "statusCode": "200",
+                "protocol": "http1",
+                "requestType": "read",
                 "serviceId": "metricsproxy-container"
               }
             },
             {
               "values": {
-                "serverActiveThreads.average": 0.0066777963272
+                "http.status.2xx.rate": 0.0666677777963
               },
               "dimensions": {
+                "httpMethod": "GET",
+                "statusCode": "200",
+                "protocol": "http1",
+                "requestType": "monitoring",
                 "serviceId": "metricsproxy-container"
               }
             },
             {
               "values": {
-                "jdisc.gc.ms.average": 2
+                "jdisc.gc.ms.average": 6.6666666666667,
+                "jdisc.gc.ms.last": 8,
+                "jdisc.gc.ms.max": 8,
+                "jdisc.gc.count.average": 0.8333333333333,
+                "jdisc.gc.count.last": 1,
+                "jdisc.gc.count.max": 1
               },
               "dimensions": {
                 "gcName": "G1YoungGeneration",
@@ -10108,194 +5259,16 @@
             },
             {
               "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
+                "jdisc.gc.ms.average": 0,
+                "jdisc.gc.ms.last": 0,
+                "jdisc.gc.ms.max": 0,
+                "jdisc.gc.count.average": 0,
+                "jdisc.gc.count.last": 0,
+                "jdisc.gc.count.max": 0
               },
               "dimensions": {
                 "gcName": "G1OldGeneration",
                 "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 52066321.333333336
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277280,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277280,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129785856,
-                "memory_rss": 16797696,
-                "cpu": 0.2836627958514,
-                "cpu_util": 0.0088644623704
-              },
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.qrserver",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 29432659968,
-                "memory_rss": 21866582016,
-                "cpu": 69.2065595494451,
-                "cpu_util": 4.3254099718403
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "degraded_queries.rate": 1.9833333333333
-              },
-              "dimensions": {
-                "chain": "default",
-                "reason": "match_phase",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "failed_queries.rate": 0,
-                "hits_per_query.average": 19.7633533421508,
-                "queries.rate": 163.8333333333333,
-                "query_latency.average": 3.8783041481331,
-                "query_latency.95percentile": 9.8046875,
-                "query_latency.99percentile": 29.4921875,
-                "totalhits_per_query.average": 265.0308271441652
-              },
-              "dimensions": {
-                "chain": "default",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.754590984975
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "ConcurrentMarkSweep",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 10615255457.333334
-              },
-              "dimensions": {
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 163.75
-              },
-              "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
               }
             },
             {
@@ -10303,89 +5276,10 @@
                 "http.status.4xx.rate": 0
               },
               "dimensions": {
-                "httpMethod": "POST",
-                "serviceId": "qrserver"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 16
-              },
-              "dimensions": {
-                "gcName": "ParNew",
-                "serviceId": "qrserver"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 975486976,
-                "memory_rss": 298639360,
-                "cpu": 0.8613549776379,
-                "cpu_util": 0.0538346861024
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0066666666667
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1.3333333333333
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
                 "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 41719070.666666664
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1333333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
+                "statusCode": "404",
+                "protocol": "http1",
+                "requestType": "read",
                 "serviceId": "metricsproxy-container"
               }
             }
@@ -10393,7 +5287,7 @@
         },
         {
           "name": "vespa.config-sentinel",
-          "timestamp": 1699277296,
+          "timestamp": 1760044773,
           "status": {
             "code": "up",
             "description": "Data collected successfully"
@@ -10411,7 +5305,15 @@
               }
             },
             {
-              "values": {},
+              "values": {
+                "sentinel.restarts.count": 0,
+                "sentinel.totalRestarts.sum": 0,
+                "sentinel.totalRestarts.max": 0,
+                "sentinel.totalRestarts.last": 0,
+                "sentinel.running.count": 597,
+                "sentinel.running.last": 9,
+                "sentinel.uptime.last": 36969.1
+              },
               "dimensions": {
                 "serviceId": "config-sentinel"
               }
@@ -10420,7 +5322,7 @@
         },
         {
           "name": "vespa.logd",
-          "timestamp": 1699277296,
+          "timestamp": 1760044773,
           "status": {
             "code": "up",
             "description": "Data collected successfully"
@@ -10428,614 +5330,402 @@
           "metrics": [
             {
               "values": {
-                "memory_virt": 129781760,
-                "memory_rss": 18767872,
-                "cpu": 0.5466291204241,
-                "cpu_util": 0.0341643200265
+                "memory_virt": 135151616,
+                "memory_rss": 3518464,
+                "cpu": 0.3038534137471,
+                "cpu_util": 0.0276230376134
               },
               "dimensions": {
                 "serviceId": "logd"
               }
             },
             {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
               "values": {
-                "memory_virt": 72331993088,
-                "memory_rss": 67431186432,
-                "cpu": 71.7797988567364,
-                "cpu_util": 2.243118714273
+                "logd.processed.lines.count": 0
               },
               "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.283333,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 9,
-                "content.proton.documentdb.documents.ready.last": 9,
-                "content.proton.documentdb.documents.total.last": 9,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10937856,
-                "content.proton.documentdb.disk_usage.last": 3674977,
-                "content.proton.transactionlog.disk_usage.last": 2779118
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001482522196,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000368981809
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "sparse_def_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.1961547020466,
-                "content.proton.resource_usage.memory.average": 0.4963181483898,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0020741964832,
-                "content.proton.search_protocol.docsum.latency.average": 0.0007806681118,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2499.466666
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 17386.15,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10328294,
-                "content.proton.documentdb.documents.ready.last": 10328294,
-                "content.proton.documentdb.documents.total.last": 10328294,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 66816479375,
-                "content.proton.documentdb.disk_usage.last": 14855490675,
-                "content.proton.transactionlog.disk_usage.last": 3125439480
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0003279888032,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0029721412073
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "sparse_abc_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 449581056,
-                "memory_rss": 238911488,
-                "cpu": 11.8489385848844,
-                "cpu_util": 0.3702793307776
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 973422592,
-                "memory_rss": 320434176,
-                "cpu": 0.6526957695063,
-                "cpu_util": 0.0203967427971
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.005
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0.8333333333333
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 56226445.333333336
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1166666666667
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277290,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 16793600,
-                "cpu": 0.3514515681957,
-                "cpu_util": 0.0109828615061
-              },
-              "dimensions": {
+                "loglevel": "error",
+                "service": "searchnode",
                 "serviceId": "logd"
               }
             },
             {
-              "values": {},
-              "dimensions": {
-                "serviceId": "logd"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "hostname": "host.com",
-      "role": "hosts/host.com",
-      "services": [
-        {
-          "name": "vespa.searchnode",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
               "values": {
-                "memory_virt": 72944189440,
-                "memory_rss": 68376244224,
-                "cpu": 64.5726028686617,
-                "cpu_util": 2.0178938396457
+                "logd.processed.lines.count": 0
               },
               "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 0.166666,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 6,
-                "content.proton.documentdb.documents.ready.last": 6,
-                "content.proton.documentdb.documents.total.last": 6,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 10821704,
-                "content.proton.documentdb.disk_usage.last": 3619672,
-                "content.proton.transactionlog.disk_usage.last": 2788717
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0001199500616,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0000308636695
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "sparse_def_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "unranked",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.resource_usage.disk.average": 0.3029391724854,
-                "content.proton.resource_usage.memory.average": 0.4999217910308,
-                "content.proton.resource_usage.feeding_blocked.last": 0,
-                "content.proton.search_protocol.query.latency.average": 0.0015622574506,
-                "content.proton.search_protocol.docsum.latency.average": 0.0006651597775,
-                "content.proton.search_protocol.docsum.requested_documents.rate": 2765.033333
-              },
-              "dimensions": {
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.docs_matched.rate": 18689.766666,
-                "content.proton.documentdb.matching.docs_reranked.rate": 0,
-                "content.proton.documentdb.documents.active.last": 10349798,
-                "content.proton.documentdb.documents.ready.last": 10349798,
-                "content.proton.documentdb.documents.total.last": 10349798,
-                "content.proton.documentdb.memory_usage.allocated_bytes.last": 67191122197,
-                "content.proton.documentdb.disk_usage.last": 15032371939,
-                "content.proton.transactionlog.disk_usage.last": 3189544960
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0.0002490099986,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0.0022304588114
-              },
-              "dimensions": {
-                "documenttype": "def",
-                "rankProfile": "sparse_abc_linear",
-                "serviceId": "searchnode"
-              }
-            },
-            {
-              "values": {
-                "content.proton.documentdb.matching.rank_profile.rerank_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_setup_time.average": 0,
-                "content.proton.documentdb.matching.rank_profile.query_latency.average": 0
-              },
-              "dimensions": {
-                "documenttype": "abc",
-                "rankProfile": "default",
-                "serviceId": "searchnode"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.distributor",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 426512384,
-                "memory_rss": 215707648,
-                "cpu": 11.3282332578606,
-                "cpu_util": 0.3540072893081
-              },
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "distributor"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.metricsproxy-container",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 980799488,
-                "memory_rss": 327004160,
-                "cpu": 0.5187226454855,
-                "cpu_util": 0.0162100826714
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "serverActiveThreads.average": 0.0100166944908
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 1
-              },
-              "dimensions": {
-                "gcName": "G1YoungGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.0833333333333
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "jdisc.gc.ms.average": 0
-              },
-              "dimensions": {
-                "gcName": "G1OldGeneration",
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "mem.heap.free.average": 40613492
-              },
-              "dimensions": {
-                "serviceId": "metricsproxy-container"
-              }
-            },
-            {
-              "values": {
-                "http.status.2xx.rate": 0.1
-              },
-              "dimensions": {
-                "httpMethod": "GET",
-                "serviceId": "metricsproxy-container"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.config-sentinel",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 0,
-                "memory_rss": 0,
-                "cpu": 0,
-                "cpu_util": 0
-              },
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            },
-            {
-              "values": {},
-              "dimensions": {
-                "serviceId": "config-sentinel"
-              }
-            }
-          ]
-        },
-        {
-          "name": "vespa.logd",
-          "timestamp": 1699277296,
-          "status": {
-            "code": "up",
-            "description": "Data collected successfully"
-          },
-          "metrics": [
-            {
-              "values": {
-                "memory_virt": 129871872,
-                "memory_rss": 16846848,
-                "cpu": 0.2844608055888,
-                "cpu_util": 0.0088894001747
-              },
-              "dimensions": {
+                "loglevel": "info",
+                "service": "logd",
                 "serviceId": "logd"
               }
             },
             {
-              "values": {},
+              "values": {
+                "logd.processed.lines.count": 0
+              },
               "dimensions": {
+                "loglevel": "event",
+                "service": "-",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "config",
+                "service": "logserver",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "config",
+                "service": "logserver-container",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "error",
+                "service": "container-clustercontroller",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "warning",
+                "service": "metricsproxy-container",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "warning",
+                "service": "configserver",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "config",
+                "service": "slobrok",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "config",
+                "service": "container-clustercontroller",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "config",
+                "service": "distributor",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "info",
+                "service": "searchnode",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "info",
+                "service": "logserver-container",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "warning",
+                "service": "container",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "event",
+                "service": "configserver",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "event",
+                "service": "distributor",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "event",
+                "service": "searchnode",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "warning",
+                "service": "container-clustercontroller",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "event",
+                "service": "config-sentinel",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "event",
+                "service": "configproxy",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "config",
+                "service": "config-sentinel",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "config",
+                "service": "configserver",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "event",
+                "service": "slobrok",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "info",
+                "service": "configproxy",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "info",
+                "service": "config-sentinel",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "warning",
+                "service": "configproxy",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "warning",
+                "service": "distributor",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "info",
+                "service": "container-clustercontroller",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "config",
+                "service": "container",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "config",
+                "service": "searchnode",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "config",
+                "service": "metricsproxy-container",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "info",
+                "service": "metricsproxy-container",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "info",
+                "service": "distributor",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "event",
+                "service": "logd",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "warning",
+                "service": "logserver-container",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "event",
+                "service": "logserver",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "info",
+                "service": "container",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "info",
+                "service": "configserver",
+                "serviceId": "logd"
+              }
+            },
+            {
+              "values": {
+                "logd.processed.lines.count": 0
+              },
+              "dimensions": {
+                "loglevel": "warning",
+                "service": "searchnode",
                 "serviceId": "logd"
               }
             }

--- a/src/main/resources/json/schema/metrics.schema.json
+++ b/src/main/resources/json/schema/metrics.schema.json
@@ -1,190 +1,2196 @@
 {
-  "type" : "object",
-  "properties" : {
-    "nodes" : {
-      "type" : "array",
-      "items" : {
+  "type": "object",
+  "properties": {
+    "nodes": {
+      "type": "array",
+      "items": {
         "javaType": "com.vispana.client.vespa.model.MetricsNode",
-        "type" : "object",
-        "properties" : {
-          "hostname" : {
-            "type" : "string"
+        "type": "object",
+        "properties": {
+          "hostname": {
+            "type": "string"
           },
-          "role" : {
-            "type" : "string"
+          "role": {
+            "type": "string"
           },
-          "services" : {
-            "type" : "array",
-            "items" : {
-              "type" : "object",
-              "properties" : {
-                "name" : {
-                  "type" : "string"
+          "services": {
+            "type": "array",
+            "items": {
+              "javaType": "com.vispana.client.vespa.model.MetricsNodeService",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
                 },
-                "timestamp" : {
-                  "type" : "integer"
+                "timestamp": {
+                  "type": "integer"
                 },
-                "status" : {
-                  "type" : "object",
-                  "properties" : {
-                    "code" : {
-                      "type" : "string"
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
                     },
-                    "description" : {
-                      "type" : "string"
+                    "description": {
+                      "type": "string"
                     }
                   }
                 },
-                "metrics" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "values" : {
-                        "type" : "object",
-                        "properties" : {
-                          "memory_virt" : {
-                            "type" : "integer"
+                "metrics": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "values": {
+                        "type": "object",
+                        "properties": {
+                          "memory_virt": {
+                            "type": "integer"
                           },
-                          "memory_rss" : {
-                            "type" : "integer"
+                          "memory_rss": {
+                            "type": "integer"
                           },
-                          "cpu" : {
-                            "type" : "number"
+                          "cpu": {
+                            "type": "number"
                           },
-                          "cpu_util" : {
-                            "type" : "number"
+                          "cpu_util": {
+                            "type": "number"
                           },
-                          "content.proton.documentdb.matching.rank_profile.rerank_time.average" : {
-                            "type" : "integer"
+                          "http.status.2xx.rate": {
+                            "type": "number"
                           },
-                          "content.proton.documentdb.matching.rank_profile.query_setup_time.average" : {
-                            "type" : "integer"
+                          "serverActiveThreads.sum": {
+                            "type": "integer"
                           },
-                          "content.proton.documentdb.matching.rank_profile.query_latency.average" : {
-                            "type" : "integer"
+                          "serverActiveThreads.count": {
+                            "type": "integer"
                           },
-                          "content.proton.documentdb.matching.docs_matched.rate" : {
-                            "type" : "number"
+                          "serverActiveThreads.last": {
+                            "type": "integer"
                           },
-                          "content.proton.documentdb.matching.docs_reranked.rate" : {
-                            "type" : "integer"
+                          "serverActiveThreads.max": {
+                            "type": "integer"
                           },
-                          "content.proton.documentdb.documents.active.last" : {
-                            "type" : "integer"
+                          "serverActiveThreads.min": {
+                            "type": "integer"
                           },
-                          "content.proton.documentdb.documents.ready.last" : {
-                            "type" : "integer"
+                          "serverThreadPoolSize.last": {
+                            "type": "integer"
                           },
-                          "content.proton.documentdb.documents.total.last" : {
-                            "type" : "integer"
+                          "serverThreadPoolSize.max": {
+                            "type": "integer"
                           },
-                          "content.proton.documentdb.memory_usage.allocated_bytes.last" : {
-                            "type" : "integer",
-                            "minimum" : 9223372036854775807
+                          "jdisc.thread_pool.work_queue.capacity.sum": {
+                            "type": "integer"
                           },
-                          "content.proton.documentdb.disk_usage.last" : {
-                            "type" : "integer",
-                            "minimum" : 9223372036854775807
+                          "jdisc.thread_pool.work_queue.capacity.count": {
+                            "type": "integer"
                           },
-                          "content.proton.transactionlog.disk_usage.last" : {
-                            "type" : "integer",
-                            "minimum" : 9223372036854775807
+                          "jdisc.thread_pool.work_queue.capacity.last": {
+                            "type": "integer"
                           },
-                          "content.proton.resource_usage.disk.average" : {
-                            "type" : "number"
+                          "jdisc.thread_pool.work_queue.capacity.max": {
+                            "type": "integer"
                           },
-                          "content.proton.resource_usage.memory.average" : {
-                            "type" : "number"
+                          "jdisc.thread_pool.work_queue.capacity.min": {
+                            "type": "integer"
                           },
-                          "content.proton.resource_usage.feeding_blocked.last" : {
-                            "type" : "integer"
+                          "jdisc.thread_pool.work_queue.size.sum": {
+                            "type": "integer"
                           },
-                          "content.proton.search_protocol.query.latency.average" : {
-                            "type" : "number"
+                          "jdisc.thread_pool.work_queue.size.count": {
+                            "type": "integer"
                           },
-                          "content.proton.search_protocol.docsum.latency.average" : {
-                            "type" : "number"
+                          "jdisc.thread_pool.work_queue.size.last": {
+                            "type": "integer"
                           },
-                          "content.proton.search_protocol.docsum.requested_documents.rate" : {
-                            "type" : "number"
+                          "jdisc.thread_pool.work_queue.size.max": {
+                            "type": "integer"
                           },
-                          "serverActiveThreads.average" : {
-                            "type" : "number"
+                          "jdisc.thread_pool.work_queue.size.min": {
+                            "type": "integer"
                           },
-                          "jdisc.gc.ms.average" : {
-                            "type" : "integer"
+                          "jdisc.thread_pool.max_allowed_size.sum": {
+                            "type": "integer"
                           },
-                          "http.status.2xx.rate" : {
-                            "type" : "number"
+                          "jdisc.thread_pool.max_allowed_size.count": {
+                            "type": "integer"
                           },
-                          "mem.heap.free.average" : {
-                            "type" : "integer"
+                          "jdisc.thread_pool.max_allowed_size.last": {
+                            "type": "integer"
                           },
-                          "degraded_queries.rate" : {
-                            "type" : "number"
+                          "jdisc.thread_pool.max_allowed_size.max": {
+                            "type": "integer"
                           },
-                          "failed_queries.rate" : {
-                            "type" : "integer"
+                          "jdisc.thread_pool.max_allowed_size.min": {
+                            "type": "integer"
                           },
-                          "hits_per_query.average" : {
-                            "type" : "number"
+                          "jdisc.thread_pool.active_threads.sum": {
+                            "type": "integer"
                           },
-                          "queries.rate" : {
-                            "type" : "number"
+                          "jdisc.thread_pool.active_threads.count": {
+                            "type": "integer"
                           },
-                          "query_latency.average" : {
-                            "type" : "number"
+                          "jdisc.thread_pool.active_threads.last": {
+                            "type": "integer"
                           },
-                          "query_latency.95percentile" : {
-                            "type" : "number"
+                          "jdisc.thread_pool.active_threads.max": {
+                            "type": "integer"
                           },
-                          "query_latency.99percentile" : {
-                            "type" : "number"
+                          "jdisc.thread_pool.active_threads.min": {
+                            "type": "integer"
                           },
-                          "totalhits_per_query.average" : {
-                            "type" : "number"
+                          "jdisc.thread_pool.size.sum": {
+                            "type": "integer"
                           },
-                          "http.status.4xx.rate" : {
-                            "type" : "integer"
+                          "jdisc.thread_pool.size.count": {
+                            "type": "integer"
                           },
-                          "feed.operations.rate" : {
-                            "type" : "integer"
+                          "jdisc.thread_pool.size.last": {
+                            "type": "integer"
+                          },
+                          "jdisc.thread_pool.size.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.thread_pool.size.min": {
+                            "type": "integer"
+                          },
+                          "jdisc.gc.ms.average": {
+                            "type": "integer"
+                          },
+                          "jdisc.gc.ms.last": {
+                            "type": "integer"
+                          },
+                          "jdisc.gc.ms.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.gc.count.average": {
+                            "type": "integer"
+                          },
+                          "jdisc.gc.count.last": {
+                            "type": "integer"
+                          },
+                          "jdisc.gc.count.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.jvm.last": {
+                            "type": "integer"
+                          },
+                          "http.status.4xx.rate": {
+                            "type": "integer"
+                          },
+                          "serverBytesSent.sum": {
+                            "type": "integer"
+                          },
+                          "serverBytesSent.count": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.request.uri_length.sum": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.request.uri_length.count": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.request.uri_length.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.requests.count": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.requests.rate": {
+                            "type": "number"
+                          },
+                          "jdisc.http.request.content_size.sum": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.request.content_size.count": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.request.content_size.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.request.requests_per_connection.average": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.request.requests_per_connection.sum": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.request.requests_per_connection.count": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.request.requests_per_connection.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.request.requests_per_connection.min": {
+                            "type": "integer"
+                          },
+                          "serverNumConnections.average": {
+                            "type": "number"
+                          },
+                          "serverNumConnections.last": {
+                            "type": "integer"
+                          },
+                          "serverNumConnections.max": {
+                            "type": "integer"
+                          },
+                          "serverNumOpenConnections.average": {
+                            "type": "number"
+                          },
+                          "serverNumOpenConnections.last": {
+                            "type": "integer"
+                          },
+                          "serverNumOpenConnections.max": {
+                            "type": "integer"
+                          },
+                          "mem.native.free.average": {
+                            "type": "number"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.total.sum": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.total.count": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.total.last": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.total.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.total.min": {
+                            "type": "integer"
+                          },
+                          "jdisc.open_file_descriptors.max": {
+                            "type": "integer"
+                          },
+                          "mem.native.used.average": {
+                            "type": "number"
+                          },
+                          "jdisc.tls.capability_checks.failed.rate": {
+                            "type": "integer"
+                          },
+                          "jdisc.deactivated_containers.total.sum": {
+                            "type": "integer"
+                          },
+                          "jdisc.deactivated_containers.total.last": {
+                            "type": "integer"
+                          },
+                          "jdisc.memory_mappings.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.max.sum": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.max.count": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.max.last": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.max.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.max.min": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.reserved.sum": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.reserved.count": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.reserved.last": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.reserved.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.reserved.min": {
+                            "type": "integer"
+                          },
+                          "mem.heap.used.average": {
+                            "type": "number"
+                          },
+                          "mem.heap.used.max": {
+                            "type": "integer"
+                          },
+                          "mem.native.total.average": {
+                            "type": "integer",
+                            "minimum": 9223372036854775807
+                          },
+                          "jdisc.tls.capability_checks.succeeded.rate": {
+                            "type": "integer"
+                          },
+                          "mem.direct.count.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.queue.size.sum": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.queue.size.count": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.queue.size.last": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.queue.size.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.queue.size.min": {
+                            "type": "integer"
+                          },
+                          "mem.direct.free.average": {
+                            "type": "integer"
+                          },
+                          "mem.heap.total.average": {
+                            "type": "integer"
+                          },
+                          "mem.direct.used.average": {
+                            "type": "integer"
+                          },
+                          "mem.direct.used.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.busy.sum": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.busy.count": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.busy.last": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.busy.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.busy.min": {
+                            "type": "integer"
+                          },
+                          "mem.direct.total.average": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.min.sum": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.min.count": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.min.last": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.min.max": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.jetty.threadpool.thread.min.min": {
+                            "type": "integer"
+                          },
+                          "mem.heap.free.average": {
+                            "type": "number"
+                          },
+                          "handled.latency.sum": {
+                            "type": "integer"
+                          },
+                          "handled.latency.count": {
+                            "type": "integer"
+                          },
+                          "handled.latency.max": {
+                            "type": "integer"
+                          },
+                          "handled.requests.count": {
+                            "type": "integer"
+                          },
+                          "slobrok.heartbeats.failed.count": {
+                            "type": "integer"
+                          },
+                          "slobrok.missing.consensus.count": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.work-ms.sum": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.work-ms.count": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.work-ms.last": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.retired.count.last": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.retired.count.max": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.maintenance.count.last": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.maintenance.count.max": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.stopping.count.last": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.nodes-not-converged.max": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.down.count.last": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.down.count.max": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.initializing.count.last": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.initializing.count.max": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.up.count.last": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.up.count.max": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.resource_usage.nodes_above_limit.last": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.resource_usage.nodes_above_limit.max": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.cluster-buckets-out-of-sync-ratio.max": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.cluster-state-change.count": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.idle-tick-time-ms.sum": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.idle-tick-time-ms.count": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.idle-tick-time-ms.last": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.idle-tick-time-ms.max": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.node-event.count": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.busy-tick-time-ms.sum": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.busy-tick-time-ms.count": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.busy-tick-time-ms.last": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.busy-tick-time-ms.max": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.resource_usage.disk_limit.last": {
+                            "type": "number"
+                          },
+                          "cluster-controller.resource_usage.disk_limit.max": {
+                            "type": "number"
+                          },
+                          "cluster-controller.resource_usage.max_memory_utilization.last": {
+                            "type": "number"
+                          },
+                          "cluster-controller.resource_usage.max_memory_utilization.max": {
+                            "type": "number"
+                          },
+                          "cluster-controller.resource_usage.max_disk_utilization.last": {
+                            "type": "number"
+                          },
+                          "cluster-controller.resource_usage.max_disk_utilization.max": {
+                            "type": "number"
+                          },
+                          "cluster-controller.resource_usage.memory_limit.last": {
+                            "type": "number"
+                          },
+                          "cluster-controller.resource_usage.memory_limit.max": {
+                            "type": "number"
+                          },
+                          "cluster-controller.is-master.last": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.is-master.max": {
+                            "type": "integer"
+                          },
+                          "cluster-controller.remote-task-queue.size.last": {
+                            "type": "integer"
+                          },
+                          "jdisc.http.handler.unhandled_exceptions.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.attribute.memory_usage.allocated_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.attribute.memory_usage.used_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.attribute.memory_usage.dead_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.attribute.memory_usage.onhold_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.attribute.disk_usage.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.index.disk_usage.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.docs_matched.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.docs_matched.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.queries.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.limited_queries.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.soft_doomed_queries.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.soft_doom_factor.sum": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.soft_doom_factor.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.soft_doom_factor.min": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.soft_doom_factor.max": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.grouping_time.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.grouping_time.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.grouping_time.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.rerank_time.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.rerank_time.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.rerank_time.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.query_setup_time.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.query_setup_time.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.query_setup_time.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.query_latency.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.query_latency.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.rank_profile.query_latency.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.job.attribute_flush.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.job.memory_index_flush.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.job.disk_index_fusion.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.job.document_store_flush.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.job.document_store_compact.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.job.bucket_move.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.job.lid_space_compact.average": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.job.removed_documents_prune.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.job.total.average": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.attribute.resource_usage.address_space.max": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.attribute.resource_usage.feeding_blocked.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.index.memory_usage.allocated_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.index.memory_usage.used_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.index.memory_usage.dead_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.index.memory_usage.onhold_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.index.docs_in_memory.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.index.docs_in_memory.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.index.io.search.read_bytes.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.index.io.search.read_bytes.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.index.io.search.cached_read_bytes.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.index.io.search.cached_read_bytes.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.lid_space.lid_limit.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.lid_space.lid_limit.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.lid_space.used_lids.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.lid_space.used_lids.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.lid_space.highest_used_lid.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.lid_space.highest_used_lid.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.lid_space.lid_bloat_factor.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.lid_space.lid_fragmentation_factor.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.document_store.disk_usage.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.document_store.disk_bloat.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.document_store.max_bucket_spread.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.document_store.memory_usage.allocated_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.document_store.memory_usage.used_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.document_store.memory_usage.onhold_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.document_store.cache.memory_usage.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.document_store.cache.hit_rate.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.document_store.cache.lookups.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.ready.document_store.cache.invalidations.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.lid_space.lid_limit.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.lid_space.lid_limit.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.lid_space.used_lids.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.lid_space.used_lids.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.lid_space.highest_used_lid.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.lid_space.highest_used_lid.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.lid_space.lid_bloat_factor.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.lid_space.lid_fragmentation_factor.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.document_store.disk_usage.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.document_store.disk_bloat.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.document_store.max_bucket_spread.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.document_store.memory_usage.allocated_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.document_store.memory_usage.used_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.document_store.memory_usage.dead_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.document_store.memory_usage.onhold_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.document_store.cache.memory_usage.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.document_store.cache.hit_rate.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.document_store.cache.lookups.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.document_store.cache.invalidations.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.lid_space.lid_limit.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.lid_space.lid_limit.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.lid_space.used_lids.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.lid_space.used_lids.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.lid_space.highest_used_lid.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.lid_space.highest_used_lid.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.lid_space.lid_bloat_factor.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.lid_space.lid_fragmentation_factor.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.document_store.disk_usage.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.document_store.disk_bloat.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.document_store.max_bucket_spread.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.document_store.memory_usage.allocated_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.document_store.memory_usage.used_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.document_store.memory_usage.dead_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.removed.document_store.memory_usage.onhold_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.threading_service.master.accepted.rate": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.threading_service.master.wakeups.rate": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.threading_service.master.utilization.sum": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.threading_service.master.utilization.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.threading_service.master.utilization.max": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.threading_service.master.queuesize.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.threading_service.master.queuesize.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.threading_service.master.queuesize.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.threading_service.index.accepted.rate": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.threading_service.index.wakeups.rate": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.threading_service.index.utilization.sum": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.threading_service.index.utilization.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.threading_service.index.utilization.max": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.threading_service.index.queuesize.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.threading_service.index.queuesize.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.threading_service.index.queuesize.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.threading_service.summary.accepted.rate": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.threading_service.summary.wakeups.rate": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.threading_service.summary.utilization.sum": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.threading_service.summary.utilization.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.threading_service.summary.utilization.max": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.threading_service.summary.queuesize.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.threading_service.summary.queuesize.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.threading_service.summary.queuesize.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.docs_matched.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.docs_matched.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.queries.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.soft_doomed_queries.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.query_setup_time.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.query_setup_time.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.query_setup_time.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.query_latency.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.query_latency.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.matching.query_latency.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.documents.active.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.documents.active.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.documents.ready.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.documents.ready.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.documents.total.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.documents.total.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.documents.removed.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.documents.removed.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.bucket_move.buckets_pending.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.bucket_move.buckets_pending.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.bucket_move.buckets_pending.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.feeding.commit.operations.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.feeding.commit.operations.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.feeding.commit.operations.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.feeding.commit.operations.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.feeding.commit.latency.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.feeding.commit.latency.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.feeding.commit.latency.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.memory_usage.allocated_bytes.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.disk_usage.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.heart_beat_age.min": {
+                            "type": "number"
+                          },
+                          "content.proton.documentdb.heart_beat_age.last": {
+                            "type": "number"
+                          },
+                          "content.proton.transactionlog.entries.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.transactionlog.disk_usage.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.transactionlog.replay_time.max": {
+                            "type": "number"
+                          },
+                          "content.proton.transactionlog.replay_time.last": {
+                            "type": "number"
+                          },
+                          "content.proton.config.generation.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.resource_usage.disk.average": {
+                            "type": "number"
+                          },
+                          "content.proton.resource_usage.memory.average": {
+                            "type": "number"
+                          },
+                          "content.proton.resource_usage.disk_usage.total.max": {
+                            "type": "number"
+                          },
+                          "content.proton.resource_usage.disk_usage.total_utilization.max": {
+                            "type": "number"
+                          },
+                          "content.proton.resource_usage.disk_usage.transient.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.resource_usage.memory_usage.total.max": {
+                            "type": "number"
+                          },
+                          "content.proton.resource_usage.memory_usage.total_utilization.max": {
+                            "type": "number"
+                          },
+                          "content.proton.resource_usage.memory_usage.transient.max": {
+                            "type": "number"
+                          },
+                          "content.proton.resource_usage.open_file_descriptors.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.resource_usage.feeding_blocked.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.resource_usage.feeding_blocked.last": {
+                            "type": "integer"
+                          },
+                          "content.proton.resource_usage.malloc_arena.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.resource_usage.cpu_util.setup.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.resource_usage.cpu_util.setup.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.resource_usage.cpu_util.setup.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.resource_usage.cpu_util.read.sum": {
+                            "type": "number"
+                          },
+                          "content.proton.resource_usage.cpu_util.read.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.resource_usage.cpu_util.read.max": {
+                            "type": "number"
+                          },
+                          "content.proton.resource_usage.cpu_util.write.sum": {
+                            "type": "number"
+                          },
+                          "content.proton.resource_usage.cpu_util.write.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.resource_usage.cpu_util.write.max": {
+                            "type": "number"
+                          },
+                          "content.proton.resource_usage.cpu_util.compact.sum": {
+                            "type": "number"
+                          },
+                          "content.proton.resource_usage.cpu_util.compact.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.resource_usage.cpu_util.compact.max": {
+                            "type": "number"
+                          },
+                          "content.proton.resource_usage.cpu_util.other.sum": {
+                            "type": "number"
+                          },
+                          "content.proton.resource_usage.cpu_util.other.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.resource_usage.cpu_util.other.max": {
+                            "type": "number"
+                          },
+                          "content.proton.executor.proton.accepted.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.proton.wakeups.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.proton.utilization.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.proton.utilization.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.proton.utilization.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.proton.queuesize.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.proton.queuesize.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.proton.queuesize.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.flush.accepted.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.flush.wakeups.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.flush.utilization.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.flush.utilization.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.flush.utilization.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.flush.queuesize.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.flush.queuesize.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.flush.queuesize.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.match.accepted.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.match.wakeups.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.match.utilization.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.match.utilization.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.match.utilization.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.match.queuesize.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.match.queuesize.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.match.queuesize.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.docsum.accepted.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.docsum.wakeups.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.docsum.utilization.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.docsum.utilization.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.docsum.utilization.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.docsum.queuesize.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.docsum.queuesize.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.docsum.queuesize.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.shared.accepted.rate": {
+                            "type": "number"
+                          },
+                          "content.proton.executor.shared.wakeups.rate": {
+                            "type": "number"
+                          },
+                          "content.proton.executor.shared.utilization.sum": {
+                            "type": "number"
+                          },
+                          "content.proton.executor.shared.utilization.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.shared.utilization.max": {
+                            "type": "number"
+                          },
+                          "content.proton.executor.shared.queuesize.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.shared.queuesize.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.shared.queuesize.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.warmup.accepted.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.warmup.wakeups.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.warmup.utilization.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.warmup.utilization.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.warmup.utilization.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.warmup.queuesize.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.warmup.queuesize.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.warmup.queuesize.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.field_writer.accepted.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.field_writer.wakeups.rate": {
+                            "type": "number"
+                          },
+                          "content.proton.executor.field_writer.utilization.sum": {
+                            "type": "number"
+                          },
+                          "content.proton.executor.field_writer.utilization.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.field_writer.utilization.max": {
+                            "type": "number"
+                          },
+                          "content.proton.executor.field_writer.saturation.sum": {
+                            "type": "number"
+                          },
+                          "content.proton.executor.field_writer.saturation.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.field_writer.saturation.max": {
+                            "type": "number"
+                          },
+                          "content.proton.executor.field_writer.queuesize.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.field_writer.queuesize.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.executor.field_writer.queuesize.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.index.cache.postinglist.memory_usage.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.index.cache.postinglist.hit_rate.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.index.cache.postinglist.lookups.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.index.cache.postinglist.invalidations.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.index.cache.bitvector.memory_usage.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.index.cache.bitvector.hit_rate.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.index.cache.bitvector.lookups.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.index.cache.bitvector.invalidations.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.docsum.docs.rate": {
+                            "type": "integer"
+                          },
+                          "content.proton.docsum.latency.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.docsum.latency.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.docsum.latency.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.query.latency.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.query.latency.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.query.latency.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.query.request_size.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.query.request_size.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.query.request_size.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.query.reply_size.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.query.reply_size.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.query.reply_size.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.docsum.latency.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.docsum.latency.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.docsum.latency.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.docsum.latency.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.docsum.request_size.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.docsum.request_size.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.docsum.request_size.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.docsum.reply_size.sum": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.docsum.reply_size.count": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.docsum.reply_size.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.search_protocol.docsum.requested_documents.count": {
+                            "type": "integer"
+                          },
+                          "vds.server.network.client.tls-connections-established.count": {
+                            "type": "integer"
+                          },
+                          "vds.server.network.client.insecure-connections-established.count": {
+                            "type": "integer"
+                          },
+                          "vds.server.network.server.tls-connections-established.count": {
+                            "type": "integer"
+                          },
+                          "vds.server.network.server.insecure-connections-established.count": {
+                            "type": "integer"
+                          },
+                          "vds.server.network.tls-handshakes-failed.count": {
+                            "type": "integer"
+                          },
+                          "vds.server.network.peer-authorization-failures.count": {
+                            "type": "integer"
+                          },
+                          "vds.server.network.tls-connections-broken.count": {
+                            "type": "integer"
+                          },
+                          "vds.server.network.failed-tls-config-reloads.count": {
+                            "type": "integer"
+                          },
+                          "vds.server.network.rpc-capability-checks-failed.count": {
+                            "type": "integer"
+                          },
+                          "vds.server.network.status-capability-checks-failed.count": {
+                            "type": "integer"
+                          },
+                          "vds.server.fnet.num-connections.count": {
+                            "type": "integer"
+                          },
+                          "vds.bouncer.clock_skew_aborts.count": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.averagequeuewaitingtime.sum": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.averagequeuewaitingtime.count": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.averagequeuewaitingtime.max": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.queuesize.sum": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.queuesize.count": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.queuesize.max": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.active_window_size.sum": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.active_window_size.count": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.active_window_size.max": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.estimated_merge_memory_usage.sum": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.estimated_merge_memory_usage.count": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.estimated_merge_memory_usage.max": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.bounced_due_to_back_pressure.rate": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.mergechains.ok.rate": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.mergechains.failures.total.rate": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.mergechains.failures.busy.rate": {
+                            "type": "integer"
+                          },
+                          "vds.mergethrottler.locallyexecutedmerges.ok.rate": {
+                            "type": "integer"
+                          },
+                          "vds.datastored.alldisks.buckets.average": {
+                            "type": "integer"
+                          },
+                          "vds.datastored.alldisks.docs.average": {
+                            "type": "integer"
+                          },
+                          "vds.datastored.alldisks.bytes.average": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.queuesize.sum": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.queuesize.count": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.queuesize.max": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.averagequeuewait.sum": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.averagequeuewait.count": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.averagequeuewait.max": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.averagevisitorlifetime.sum": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.averagevisitorlifetime.count": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.averagevisitorlifetime.max": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.averagemessagesendtime.sum": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.averagemessagesendtime.count": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.averagemessagesendtime.max": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.averageprocessingtime.sum": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.averageprocessingtime.count": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.averageprocessingtime.max": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.created.rate": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.completed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.visitor.allthreads.failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.put.count.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.put.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.put.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.put.latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.put.failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.put.request_size.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.put.request_size.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.put.request_size.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.put.test_and_set_failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.get.count.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.get.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.get.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.get.latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.get.failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.get.request_size.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.get.request_size.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.get.request_size.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove.count.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove.latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove.failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove.request_size.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove.request_size.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove.request_size.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove.test_and_set_failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove_location.count.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove_location.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove_location.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove_location.latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.update.count.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.update.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.update.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.update.latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.update.failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.update.request_size.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.update.request_size.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.update.request_size.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.update.test_and_set_failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.createiterator.count.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.createiterator.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.createiterator.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.createiterator.latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.visit.count.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.visit.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.visit.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.visit.latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.deletebuckets.count.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.deletebuckets.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.deletebuckets.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.deletebuckets.latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.deletebuckets.failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove_by_gid.count.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove_by_gid.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove_by_gid.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove_by_gid.latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.remove_by_gid.failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.splitbuckets.count.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.joinbuckets.count.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.setbucketstates.count.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.mergemetadatareadlatency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.mergemetadatareadlatency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.mergemetadatareadlatency.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.mergedatareadlatency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.mergedatareadlatency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.mergedatareadlatency.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.mergedatawritelatency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.mergedatawritelatency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.mergedatawritelatency.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.merge_put_latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.merge_put_latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.merge_put_latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.merge_remove_latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.merge_remove_latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allthreads.merge_remove_latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allstripes.throttled_rpc_direct_dispatches.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allstripes.throttled_persistence_thread_polls.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.allstripes.timeouts_waiting_for_throttle_token.rate": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.averagequeuewait.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.averagequeuewait.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.averagequeuewait.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.queuesize.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.queuesize.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.queuesize.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.throttle_window_size.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.throttle_window_size.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.throttle_window_size.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.throttle_waiting_threads.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.throttle_waiting_threads.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.throttle_waiting_threads.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.throttle_active_tokens.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.throttle_active_tokens.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.throttle_active_tokens.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.active_operations.size.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.active_operations.size.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.active_operations.size.max": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.active_operations.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.active_operations.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.filestor.active_operations.latency.max": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.attribute.memory_usage.allocated_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.attribute.memory_usage.used_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.attribute.memory_usage.dead_bytes.average": {
+                            "type": "integer"
+                          },
+                          "content.proton.documentdb.notready.attribute.memory_usage.onhold_bytes.average": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.ok.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.failures.total.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.failures.notready.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.failures.notconnected.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.failures.wrongdistributor.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.failures.safe_time_not_reached.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.failures.storagefailure.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.failures.timeout.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.failures.busy.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.failures.inconsistent_bucket.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.failures.notfound.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.failures.concurrent_mutations.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.puts.failures.test_and_set_failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.updates.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.updates.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.updates.latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.updates.ok.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.updates.failures.total.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.updates.failures.notfound.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.updates.failures.concurrent_mutations.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.updates.failures.test_and_set_failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.updates.diverging_timestamp_updates.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.removes.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.removes.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.removes.latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.removes.ok.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.removes.failures.total.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.removes.failures.notfound.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.removes.failures.concurrent_mutations.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.removes.failures.test_and_set_failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.removelocations.ok.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.removelocations.failures.total.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.gets.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.gets.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.gets.latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.gets.ok.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.gets.failures.total.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.gets.failures.notfound.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.visitor.latency.sum": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.visitor.latency.count": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.visitor.latency.max": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.visitor.ok.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.visitor.failures.total.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.visitor.failures.notready.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.visitor.failures.notconnected.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.visitor.failures.wrongdistributor.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.visitor.failures.safe_time_not_reached.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.visitor.failures.storagefailure.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.visitor.failures.timeout.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.visitor.failures.busy.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.visitor.failures.inconsistent_bucket.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.visitor.failures.notfound.rate": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.docsstored.average": {
+                            "type": "integer"
+                          },
+                          "vds.distributor.bytesstored.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.idealstate_diff.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.buckets_toofewcopies.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.buckets_toomanycopies.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.buckets.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.buckets_notrusted.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.buckets_rechecking.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.bucket_replicas_moving_out.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.bucket_replicas_copying_in.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.bucket_replicas_copying_out.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.bucket_replicas_syncing.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.max_observed_time_since_last_gc_sec.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.delete_bucket.pending.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.delete_bucket.done_ok.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.delete_bucket.done_failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.merge_bucket.pending.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.merge_bucket.done_ok.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.merge_bucket.done_failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.merge_bucket.blocked.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.merge_bucket.throttled.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.merge_bucket.source_only_copy_changed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.merge_bucket.source_only_copy_delete_blocked.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.merge_bucket.source_only_copy_delete_failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.split_bucket.pending.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.split_bucket.done_ok.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.split_bucket.done_failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.join_bucket.pending.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.join_bucket.done_ok.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.join_bucket.done_failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.garbage_collection.pending.average": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.garbage_collection.done_ok.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.garbage_collection.done_failed.rate": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.garbage_collection.documents_removed.count": {
+                            "type": "integer"
+                          },
+                          "vds.idealstate.garbage_collection.documents_removed.rate": {
+                            "type": "integer"
+                          },
+                          "sentinel.restarts.count": {
+                            "type": "integer"
+                          },
+                          "sentinel.totalRestarts.sum": {
+                            "type": "integer"
+                          },
+                          "sentinel.totalRestarts.max": {
+                            "type": "integer"
+                          },
+                          "sentinel.totalRestarts.last": {
+                            "type": "integer"
+                          },
+                          "sentinel.running.count": {
+                            "type": "integer"
+                          },
+                          "sentinel.running.last": {
+                            "type": "integer"
+                          },
+                          "sentinel.uptime.last": {
+                            "type": "number"
+                          },
+                          "logd.processed.lines.count": {
+                            "type": "integer"
                           }
                         }
                       },
-                      "dimensions" : {
-                        "type" : "object",
-                        "properties" : {
-                          "serviceId" : {
-                            "type" : "string"
+                      "dimensions": {
+                        "type": "object",
+                        "properties": {
+                          "serviceId": {
+                            "type": "string"
                           },
-                          "rankProfile" : {
-                            "type" : "string"
+                          "httpMethod": {
+                            "type": "string"
                           },
-                          "documenttype" : {
-                            "type" : "string"
+                          "statusCode": {
+                            "type": "string"
                           },
-                          "gcName" : {
-                            "type" : "string"
+                          "protocol": {
+                            "type": "string"
                           },
-                          "httpMethod" : {
-                            "type" : "string"
+                          "requestType": {
+                            "type": "string"
                           },
-                          "reason" : {
-                            "type" : "string"
+                          "threadpool": {
+                            "type": "string"
                           },
-                          "chain" : {
-                            "type" : "string"
+                          "gcName": {
+                            "type": "string"
                           },
-                          "status" : {
-                            "type" : "string"
+                          "vendor": {
+                            "type": "string"
                           },
-                          "api" : {
-                            "type" : "string"
+                          "serverPort": {
+                            "type": "string"
                           },
-                          "operation" : {
-                            "type" : "string"
+                          "serverName": {
+                            "type": "string"
+                          },
+                          "handler": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "handler-name": {
+                            "type": "string"
+                          },
+                          "workId": {
+                            "type": "string"
+                          },
+                          "cluster": {
+                            "type": "string"
+                          },
+                          "didWork": {
+                            "type": "string"
+                          },
+                          "controller-index": {
+                            "type": "string"
+                          },
+                          "clusterId": {
+                            "type": "string"
+                          },
+                          "node-type": {
+                            "type": "string"
+                          },
+                          "field": {
+                            "type": "string"
+                          },
+                          "documenttype": {
+                            "type": "string"
+                          },
+                          "rankProfile": {
+                            "type": "string"
+                          },
+                          "loglevel": {
+                            "type": "string"
+                          },
+                          "service": {
+                            "type": "string"
                           }
                         }
                       }


### PR DESCRIPTION
I used the [consumer=vespa](https://docs.vespa.ai/en/operations/metrics.html) to get all metrics from config.
The info is displayed both in the overview, and on each content node, to quickly see which one is late.
I am considering displaying this info for each query container node as well.